### PR TITLE
Add support for CSM Authorization sidecar via Helm

### DIFF
--- a/dell-csi-helm-installer/verify-csi-powermax.sh
+++ b/dell-csi-helm-installer/verify-csi-powermax.sh
@@ -22,6 +22,7 @@ function verify-csi-powermax() {
   verify_optional_replication_requirements
   verify_iscsi_installation
   verify_helm_3
+  verify_authorization_proxy_server
 }
 
 function verify_optional_replication_requirements() {

--- a/helm/csi-powermax/templates/controller.yaml
+++ b/helm/csi-powermax/templates/controller.yaml
@@ -246,13 +246,13 @@ spec:
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
         - name: karavi-authorization-proxy
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           image: {{ required "Must provide the authorization sidecar container image." .Values.authorization.sidecarProxyImage }}
           env:
             - name: PROXY_HOST
               value: "{{ .Values.authorization.proxyHost }}"
             - name: INSECURE
-              value: "{{ .Values.authorization.insecure }}"
+              value: "{{ .Values.authorization.skipCertificateValidation }}"
             - name: PLUGIN_IDENTIFIER
               value: powermax
             - name: ACCESS_TOKEN

--- a/helm/csi-powermax/templates/controller.yaml
+++ b/helm/csi-powermax/templates/controller.yaml
@@ -108,6 +108,12 @@ kind: Deployment
 metadata:
   name: {{ .Release.Name }}-controller
   namespace: {{ .Release.Namespace }}
+  {{- if hasKey .Values "authorization" }}
+  {{- if eq .Values.authorization.enabled true }}
+  annotations:
+      com.dell.karavi-authorization-proxy: "true"
+  {{ end }}
+  {{ end }}
 spec:
   replicas: {{ required "Must provide the number of controller instances to create." .Values.controller.controllerCount }}
   selector:
@@ -235,8 +241,39 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
-          {{- end }}
-          {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- if hasKey .Values "authorization" }}
+        {{- if eq .Values.authorization.enabled true }}
+        - name: karavi-authorization-proxy
+          imagePullPolicy: Always
+          image: {{ required "Must provide the authorization sidecar container image." .Values.authorization.sidecarProxyImage }}
+          env:
+            - name: PROXY_HOST
+              value: "{{ .Values.authorization.proxyHost }}"
+            - name: INSECURE
+              value: "{{ .Values.authorization.insecure }}"
+            - name: PLUGIN_IDENTIFIER
+              value: powermax
+            - name: ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-authz-tokens
+                  key: access
+            - name: REFRESH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-authz-tokens
+                  key: refresh
+          volumeMounts:
+            - name: karavi-authorization-config
+              mountPath: /etc/karavi-authorization/config
+            - name: proxy-server-root-certificate
+              mountPath: /etc/karavi-authorization/root-certificates
+            - name: powermax-config-params
+              mountPath: /etc/karavi-authorization
+        {{- end }}
+        {{- end }}
         - name: driver
           image: {{ required "Must provide the PowerMax driver container image." .Values.images.driver }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -370,3 +407,13 @@ spec:
         - name: powermax-config-params
           configMap:
             name: {{ .Release.Name }}-config-params
+        {{- if hasKey .Values "authorization" }}
+        {{- if eq .Values.authorization.enabled true }}
+        - name: karavi-authorization-config
+          secret:
+            secretName: karavi-authorization-config
+        - name: proxy-server-root-certificate
+          secret:
+            secretName: proxy-server-root-certificate
+        {{ end }}
+        {{ end }}

--- a/helm/csi-powermax/templates/node.yaml
+++ b/helm/csi-powermax/templates/node.yaml
@@ -46,6 +46,12 @@ apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-node
   namespace: {{ .Release.Namespace }}
+  {{- if hasKey .Values "authorization" }}
+  {{- if eq .Values.authorization.enabled true }}
+  annotations:
+    com.dell.karavi-authorization-proxy: "true"
+  {{ end }}
+  {{ end }}
 spec:
   selector:
     matchLabels:
@@ -209,6 +215,37 @@ spec:
               mountPath: /registration
             - name: driver-path
               mountPath: /csi
+        {{- if hasKey .Values "authorization" }}
+        {{- if eq .Values.authorization.enabled true }}
+        - name: karavi-authorization-proxy
+          imagePullPolicy: Always
+          image: {{ required "Must provide the authorization sidecar container image." .Values.authorization.sidecarProxyImage }}
+          env:
+            - name: PROXY_HOST
+              value: "{{ .Values.authorization.proxyHost }}"
+            - name: INSECURE
+              value: "{{ .Values.authorization.insecure }}"
+            - name: PLUGIN_IDENTIFIER
+              value: powermax
+            - name: ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-authz-tokens
+                  key: access
+            - name: REFRESH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-authz-tokens
+                  key: refresh
+          volumeMounts:
+            - name: karavi-authorization-config
+              mountPath: /etc/karavi-authorization/config
+            - name: proxy-server-root-certificate
+              mountPath: /etc/karavi-authorization/root-certificates
+            - name: powermax-config-params
+              mountPath: /etc/karavi-authorization
+        {{ end }}
+        {{ end }}
       volumes:
         - name: registration-dir
           hostPath:
@@ -249,3 +286,13 @@ spec:
           secret:
               secretName: {{ .Release.Name }}-certs
               optional: true
+      {{- if hasKey .Values "authorization" }}
+      {{- if eq .Values.authorization.enabled true }}
+        - name: karavi-authorization-config
+          secret:
+            secretName: karavi-authorization-config
+        - name: proxy-server-root-certificate
+          secret:
+            secretName: proxy-server-root-certificate
+      {{ end }}
+      {{ end }}

--- a/helm/csi-powermax/templates/node.yaml
+++ b/helm/csi-powermax/templates/node.yaml
@@ -218,13 +218,13 @@ spec:
         {{- if hasKey .Values "authorization" }}
         {{- if eq .Values.authorization.enabled true }}
         - name: karavi-authorization-proxy
-          imagePullPolicy: Always
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
           image: {{ required "Must provide the authorization sidecar container image." .Values.authorization.sidecarProxyImage }}
           env:
             - name: PROXY_HOST
               value: "{{ .Values.authorization.proxyHost }}"
             - name: INSECURE
-              value: "{{ .Values.authorization.insecure }}"
+              value: "{{ .Values.authorization.skipCertificateValidation }}"
             - name: PLUGIN_IDENTIFIER
               value: powermax
             - name: ACCESS_TOKEN

--- a/helm/csi-powermax/values.yaml
+++ b/helm/csi-powermax/values.yaml
@@ -334,3 +334,17 @@ replication:
   # Default value: "replication.storage.dell.com"
   # Examples: "replication.storage.dell.com", "rdf.storage.dell.com"
   replicationPrefix: "replication.storage.dell.com"
+
+# Authorization: enable csm-authorization for RBAC
+authorization:
+  # enable: Enable/Disable csm-authorization
+  enabled: false
+
+  # sidecarProxyImage: the container images used for the csm-authorization-sidecar.
+  sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.0.0
+
+  # proxyHost: hostname of the csm-authorization server
+  proxyHost:
+
+  # insecure: Enable/Disable certificate validation of the csm-authorization server
+  insecure: true

--- a/helm/csi-powermax/values.yaml
+++ b/helm/csi-powermax/values.yaml
@@ -337,17 +337,26 @@ replication:
   # Examples: "replication.storage.dell.com", "rdf.storage.dell.com"
   replicationPrefix: "replication.storage.dell.com"
 
-# Authorization: enable csm-authorization for RBAC
+# CSM module attributes
+# authorization: enable csm-authorization for RBAC
+# Deploy and configure authorization before installing driver
+# Allowed values:
+#   "true" - authorization is enabled
+#   "false" - authorization is disabled
+# Default value: "false"
 authorization:
-  # enabled: Enable/Disable csm-authorization
   enabled: false
-
-  # sidecarProxyImage: the container images used for the csm-authorization-sidecar.
+  # sidecarProxyImage: the container image used for the csm-authorization-sidecar.
+  # Default value: dellemc/csm-authorization-sidecar:v1.0.0
+  # Example: 0.0.0.1:5000/csm-authorization-sidecar:v1.0.0
   sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.0.0
-
   # proxyHost: hostname of the csm-authorization server
+  # Default value: None
   proxyHost:
-
-  # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server
+  # skipCertificateValidation: certificate validation of the csm-authorization server
+  # Allowed Values:
+  #   "true" - TLS certificate verification will be skipped
+  #   "false" - TLS certificate will be verified 
+  # Default value: "true" 
   skipCertificateValidation: true
   

--- a/helm/csi-powermax/values.yaml
+++ b/helm/csi-powermax/values.yaml
@@ -26,10 +26,10 @@ global:
     - storageArrayId: "000000000001"
     - storageArrayId: "000000000002"
   # Address of the Unisphere server that is managing the PowerMax arrays
-  # Default value: None
-  # Example: https://0.0.0.1:8443
   # If authorization is enabled, endpoint should be the HTTPS localhost endpoint that 
   # the authorization sidecar will listen on
+  # Default value: None
+  # Example: https://0.0.0.1:8443
   managementServers:
     - endpoint: https://unisphere-address:8443
   # Current version of the driver
@@ -41,8 +41,6 @@ global:
 # Please refer to the doc website about a
 # detailed explanation of each configuration parameter
 # and the various ReverseProxy modes
-# If authorization is enabled, endpoint and backupEndpoint should be the HTTPS localhost endpoint that 
-# the authorization sidecar will listen on. Increment port for each storage array used
 
 #  defaultCredentialsSecret: powermax-creds
 #  storageArrays:
@@ -341,7 +339,7 @@ replication:
 
 # Authorization: enable csm-authorization for RBAC
 authorization:
-  # enable: Enable/Disable csm-authorization
+  # enabled: Enable/Disable csm-authorization
   enabled: false
 
   # sidecarProxyImage: the container images used for the csm-authorization-sidecar.
@@ -350,5 +348,6 @@ authorization:
   # proxyHost: hostname of the csm-authorization server
   proxyHost:
 
-  # insecure: Enable/Disable certificate validation of the csm-authorization server
-  insecure: true
+  # skipCertificateValidation: Enable/Disable certificate validation of the csm-authorization server
+  skipCertificateValidation: true
+  

--- a/helm/csi-powermax/values.yaml
+++ b/helm/csi-powermax/values.yaml
@@ -28,6 +28,8 @@ global:
   # Address of the Unisphere server that is managing the PowerMax arrays
   # Default value: None
   # Example: https://0.0.0.1:8443
+  # If authorization is enabled, endpoint should be the HTTPS localhost endpoint that 
+  # the authorization sidecar will listen on
   managementServers:
     - endpoint: https://unisphere-address:8443
   # Current version of the driver
@@ -39,6 +41,8 @@ global:
 # Please refer to the doc website about a
 # detailed explanation of each configuration parameter
 # and the various ReverseProxy modes
+# If authorization is enabled, endpoint and backupEndpoint should be the HTTPS localhost endpoint that 
+# the authorization sidecar will listen on. Increment port for each storage array used
 
 #  defaultCredentialsSecret: powermax-creds
 #  storageArrays:

--- a/samples/secret/karavi-authorization-config.json
+++ b/samples/secret/karavi-authorization-config.json
@@ -1,0 +1,1 @@
+[{"username":"","password":"","intendedEndpoint":"https://unisphere-address:8443","endpoint":"https://localhost:9400","systemID":"000000000001","insecure":true,"isDefault":true}]

--- a/samples/secret/secret.yaml
+++ b/samples/secret/secret.yaml
@@ -6,8 +6,10 @@ metadata:
 type: Opaque
 data:
   # set username to the base64 encoded username
+  # if authorization is enabled, username will be ignored
   username: bm90X3RoZV91c2VybmFtZQ==
   # set password to the base64 encoded password
+  # if authorization is enabled, password will be ignored
   password: bm90X3RoZV9wYXNzd29yZA==
   # Uncomment the following key if you wish to use ISCSI CHAP authentication (v1.3.0 onwards)
   # chapsecret: <base64 CHAP secret>


### PR DESCRIPTION
# Description
This PR implements install support for CSM Authorization sidecar in the helm chart

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/78|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- The PowerMax driver is deployed via Helm with Authorization disabled.  Ensured the Authorization sidecar does not get deployed.
- The PowerMax driver is deployed via Helm with Authorization enabled.  Ensured the Authorization sidecar is deployed and works correctly.
- There is an existing cluster with the PowerMax driver deployed and the previous version of the Authorization sidecar deployed.  The Authorization sidecar is upgraded via the driver's helm chart.
