### PR TITLE
Enabling ppc64le cross-build with $XGOARCH

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,0 +1,21 @@
+# Dockerfile to build PowerMax CSI Driver
+FROM docker.io/ppc64le/centos:8
+
+# dependencies, following by cleaning the cache
+RUN yum install -y \
+    e2fsprogs \
+    which \
+    xfsprogs \
+    device-mapper-multipath \
+    && \
+    yum clean all \
+    && \
+    rm -rf /var/cache/run
+
+# validate some cli utilities are found
+RUN which mkfs.ext4
+RUN which mkfs.xfs
+
+COPY "csi-powermax" .
+COPY "csi-powermax.sh" .
+ENTRYPOINT ["/csi-powermax.sh"]

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ clean:
 
 build: golint check
 	go generate
-	CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
+	CGO_ENABLED=0 GOOS=linux GO111MODULE=on GOARCH=$(XGOARCH) go build
 
 install:
 	go generate

--- a/docker.mk
+++ b/docker.mk
@@ -11,7 +11,7 @@ VERSION="v$(MAJOR).$(MINOR).$(PATCH).$(BUILD)$(TYPE)"
 REGISTRY="localhost:5000/csi-powermax"
 
 docker:
-	docker build -t "$(REGISTRY):$(VERSION)" .
+	test -z "$(XGOARCH)" && docker build -t "$(REGISTRY):$(VERSION)" . || buildah bud -f Dockerfile.$(XGOARCH) -t $(REGISTRY):$(VERSION)
 
 push:   
 	docker push "$(REGISTRY):$(VERSION)"


### PR DESCRIPTION
Signed-off-by: Hiro Miyamoto <miyamotoh@us.ibm.com>

# Description
The purpose of this PR is to start a pattern for adding support for more architectures, as I found out that the current 
code base couldn't be built on IBM Power (ppc64le) platform.

The basic idea is to leverage GO's cross-compiling capability and use `buildah` command to produce the Docker image for the target platform.

At this time, changes for `README.md` are not included, though I'd happily add that to this PR, once the final command line args are agreed and approved. So, at this time, I'm looking for discussion/approval for this approach to add multi-arch support to this project. Thanks!!

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
The changes proposed are successfully tested by;
1. compiling natively (as before) on x86, with passing unit-tests
2. compiling natively (as before) on ppc64le, with passing unit-tests
3. cross-compiling on x86, producing ppc64le binary/image, and passing all volume tests on running OpenShift 4.7 cluster