### PR TITLE
StorageClass parameter fsType is replaced with csi.storage.k8s.io/fstype

### DIFF
--- a/samples/storageclass/powermax.yaml
+++ b/samples/storageclass/powermax.yaml
@@ -15,6 +15,15 @@ metadata:
     # Default value: "false"
     storageclass.beta.kubernetes.io/is-default-class: <isDefault>
 parameters:
+  # "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
+  # Allowed values:
+  #   "ext4" - EXT4 File system
+  #   "xfs"  - XFS File system
+  # Optional: true
+  # Default value: None if defaultFsType is not mentioned in values.yaml
+  # Else defaultFsType value mentioned in values.yaml
+  # will be used as default value
+  csi.storage.k8s.io/fstype: xfs
   # Name of SRP on the PowerMax array that should be used for provisioning
   # Optional: false
   # Examples: "DEFAULT_SRP" , "SRP_1"
@@ -43,12 +52,3 @@ provisioner: csi-powermax.dellemc.com
 #   Retain: the underlying persistent volume remain.
 # Optional: true, Default value: None
 reclaimPolicy: Delete
-# "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
-# Allowed values:
-#   "ext4" - EXT4 File system
-#   "xfs"  - XFS File system
-# Optional: true
-# Default value: None if defaultFsType is not mentioned in values.yaml
-# Else defaultFsType value mentioned in values.yaml
-# will be used as default value
-csi.storage.k8s.io/fstype: xfs

--- a/samples/storageclass/powermax.yaml
+++ b/samples/storageclass/powermax.yaml
@@ -43,3 +43,12 @@ provisioner: csi-powermax.dellemc.com
 #   Retain: the underlying persistent volume remain.
 # Optional: true, Default value: None
 reclaimPolicy: Delete
+# "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
+# Allowed values:
+#   "ext4" - EXT4 File system
+#   "xfs"  - XFS File system
+# Optional: true
+# Default value: None if defaultFsType is not mentioned in values.yaml
+# Else defaultFsType value mentioned in values.yaml
+# will be used as default value
+csi.storage.k8s.io/fstype: xfs

--- a/samples/storageclass/powermax_fc.yaml
+++ b/samples/storageclass/powermax_fc.yaml
@@ -12,6 +12,15 @@ kind: StorageClass
 metadata:
   name: powermax-fc
 parameters:
+  # "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
+  # Allowed values:
+  #   "ext4" - EXT4 File system
+  #   "xfs"  - XFS File system
+  # Optional: true
+  # Default value: None if defaultFsType is not mentioned in values.yaml
+  # Else defaultFsType value mentioned in values.yaml
+  # will be used as default value
+  csi.storage.k8s.io/fstype: xfs
   # Name of SRP on the PowerMax array that should be used for provisioning
   # Optional: false
   # Examples: "DEFAULT_SRP" , "SRP_1"
@@ -61,12 +70,4 @@ allowedTopologies:
       - key: csi-powermax.dellemc.com/<SYMID>.fc
         values:
           - csi-powermax.dellemc.com
-# "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
-# Allowed values:
-#   "ext4" - EXT4 File system
-#   "xfs"  - XFS File system
-# Optional: true
-# Default value: None if defaultFsType is not mentioned in values.yaml
-# Else defaultFsType value mentioned in values.yaml
-# will be used as default value
-csi.storage.k8s.io/fstype: xfs
+

--- a/samples/storageclass/powermax_fc.yaml
+++ b/samples/storageclass/powermax_fc.yaml
@@ -61,3 +61,12 @@ allowedTopologies:
       - key: csi-powermax.dellemc.com/<SYMID>.fc
         values:
           - csi-powermax.dellemc.com
+# "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
+# Allowed values:
+#   "ext4" - EXT4 File system
+#   "xfs"  - XFS File system
+# Optional: true
+# Default value: None if defaultFsType is not mentioned in values.yaml
+# Else defaultFsType value mentioned in values.yaml
+# will be used as default value
+csi.storage.k8s.io/fstype: xfs

--- a/samples/storageclass/powermax_iscsi.yaml
+++ b/samples/storageclass/powermax_iscsi.yaml
@@ -61,3 +61,12 @@ allowedTopologies:
       - key: csi-powermax.dellemc.com/<SYMID>.iscsi
         values:
           - csi-powermax.dellemc.com
+# "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
+# Allowed values:
+#   "ext4" - EXT4 File system
+#   "xfs"  - XFS File system
+# Optional: true
+# Default value: None if defaultFsType is not mentioned in values.yaml
+# Else defaultFsType value mentioned in values.yaml
+# will be used as default value
+csi.storage.k8s.io/fstype: xfs

--- a/samples/storageclass/powermax_iscsi.yaml
+++ b/samples/storageclass/powermax_iscsi.yaml
@@ -12,6 +12,15 @@ kind: StorageClass
 metadata:
   name: powermax-iscsi
 parameters:
+  # "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
+  # Allowed values:
+  #   "ext4" - EXT4 File system
+  #   "xfs"  - XFS File system
+  # Optional: true
+  # Default value: None if defaultFsType is not mentioned in values.yaml
+  # Else defaultFsType value mentioned in values.yaml
+  # will be used as default value
+  csi.storage.k8s.io/fstype: xfs
   # Name of SRP on PowerMax array that should be used for provisioning
   # Optional: false
   # Examples: "DEFAULT_SRP" , "SRP_1"
@@ -61,12 +70,3 @@ allowedTopologies:
       - key: csi-powermax.dellemc.com/<SYMID>.iscsi
         values:
           - csi-powermax.dellemc.com
-# "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
-# Allowed values:
-#   "ext4" - EXT4 File system
-#   "xfs"  - XFS File system
-# Optional: true
-# Default value: None if defaultFsType is not mentioned in values.yaml
-# Else defaultFsType value mentioned in values.yaml
-# will be used as default value
-csi.storage.k8s.io/fstype: xfs

--- a/samples/storageclass/powermax_srdf.yaml
+++ b/samples/storageclass/powermax_srdf.yaml
@@ -16,7 +16,16 @@ metadata:
 parameters:
   #######################
   # k8s/driver attributes
-  #######################
+  #######################  
+  # "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
+  # Allowed values:
+  #   "ext4" - EXT4 File system
+  #   "xfs"  - XFS File system
+  # Optional: true
+  # Default value: None if defaultFsType is not mentioned in values.yaml
+  # Else defaultFsType value mentioned in values.yaml
+  # will be used as default value
+  csi.storage.k8s.io/fstype: xfs
   # Name of SRP on the PowerMax array that should be used for provisioning
   # Optional: false
   # Examples: "DEFAULT_SRP" , "SRP_1"
@@ -102,12 +111,3 @@ reclaimPolicy: Delete
 #              until a Pod using the PersistentVolumeClaim is created
 # Default value: None
 volumeBindingMode: Immediate
-# "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
-# Allowed values:
-#   "ext4" - EXT4 File system
-#   "xfs"  - XFS File system
-# Optional: true
-# Default value: None if defaultFsType is not mentioned in values.yaml
-# Else defaultFsType value mentioned in values.yaml
-# will be used as default value
-csi.storage.k8s.io/fstype: xfs

--- a/samples/storageclass/powermax_srdf.yaml
+++ b/samples/storageclass/powermax_srdf.yaml
@@ -102,3 +102,12 @@ reclaimPolicy: Delete
 #              until a Pod using the PersistentVolumeClaim is created
 # Default value: None
 volumeBindingMode: Immediate
+# "csi.storage.k8s.io/fstype" is used to set the filesystem type which will be used to format the new volume
+# Allowed values:
+#   "ext4" - EXT4 File system
+#   "xfs"  - XFS File system
+# Optional: true
+# Default value: None if defaultFsType is not mentioned in values.yaml
+# Else defaultFsType value mentioned in values.yaml
+# will be used as default value
+csi.storage.k8s.io/fstype: xfs

--- a/samples/storageclass/powermax_xfs.yaml
+++ b/samples/storageclass/powermax_xfs.yaml
@@ -8,15 +8,15 @@ kind: StorageClass
 metadata:
   name: powermax-xfs
 parameters:
-  # "FsType" is used to set the FS type which will be used
+  # "csi.storage.k8s.io/fstype" is used to set the FS type which will be used
   # Allowed values:
   #   "ext4" - EXT4 File system
   #   "xfs"  - XFS File system
   # Optional: true
-  # Default value: ext4 if defaultFsType is not mentioned in values.yaml
+  # Default value: None if defaultFsType is not mentioned in values.yaml
   # Else defaultFsType value mentioned in values.yaml
   # will be used as default value
-  FsType: xfs
+  csi.storage.k8s.io/fstype: xfs
   # Name of SRP on the PowerMax array that should be used for provisioning
   # Optional: false
   # Examples: "DEFAULT_SRP" , "SRP_1"


### PR DESCRIPTION
# Description
StorageClass parameter fsType is replaced with csi.storage.k8s.io/fstype as it is deprecated.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/188 |

# Checklist:

- [X] Have you run format,vet & lint checks against your submission?
- [X] Have you made sure that the code compiles?
- [X] Did you run the unit & integration tests successfully?
- [X] Have you maintained at least 90% code coverage?
- [X] Have you commented your code, particularly in hard-to-understand areas
- [X] Have you done corresponding changes to the documentation
- [X] Did you run tests in a real Kubernetes cluster?
- [X] Backward compatibility is not broken

# How Has This Been Tested?
SC, PVC, and pod has been created and the volumes mounted are of the FSType passed in storage class