### PR TITLE
Fixes node yaml to check for topology enable param

### DIFF
--- a/helm/csi-powermax/templates/node.yaml
+++ b/helm/csi-powermax/templates/node.yaml
@@ -207,8 +207,12 @@ spec:
               mountPath: /run/dbus/system_bus_socket
             - name: powermax-config-params
               mountPath: /powermax-config-params
+            {{ - if hasKey .Values.node "topologyControl" }}
+            {{ - if eq .Values.node.topologyControl.enabled true }}
             - name: node-topology-config
               mountPath: /node-topology-config
+            {{- end }}
+            {{- end }}
         - name: registrar
           image: {{ required "Must provide the CSI node registrar container image." ( include "csi-powermax.registrarImage" . ) }}
           args:
@@ -298,9 +302,13 @@ spec:
         - name: powermax-config-params
           configMap:
             name: {{ .Release.Name }}-config-params
+      {{- if hasKey .Values "topologyControl" }}
+      {{- if eq .Values.topologyControl.enabled true }}
         - name: node-topology-config
           configMap:
             name: node-topology-config
+      {{- end }}
+      {{- end }}
         - name: certs
           secret:
               secretName: {{ .Release.Name }}-certs

--- a/service/node.go
+++ b/service/node.go
@@ -899,7 +899,7 @@ func (s *service) checkIfArrayProtocolValid(nodeName string, array string, proto
 			return false
 		}
 	}
-	log.Debugf("applied topo key for node %s : %+v \n", nodeName, key)
+	log.Debugf("applied topo key for node %s : %+v", nodeName, key)
 	return true
 }
 


### PR DESCRIPTION
# Description
Fixes node YAML to check if the topology is enabled before creating config map and mounting it.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/300|

# Checklist:

- [X] Have you run format,vet & lint checks against your submission?
- [X] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [X] Did you run tests in a real Kubernetes cluster?
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Cluster testing:
_root@master-1-pPQwD72vsAduH:~/csi-powermax/dell-csi-helm-installer# kubectl logs powermax-node-rl7cr -n powermax driver
time="2022-05-13T07:53:28Z" level=info msg="Read CSI_LOG_FORMAT: text from configuration file"
time="2022-05-13T07:53:28Z" level=info msg="Read CSI_LOG_LEVEL: debug from config file"
time="2022-05-13T07:53:28Z" level=info msg="Setting log level to debug"
time="2022-05-13T07:53:28Z" level=error msg=**"unable to read topology config file" error="open /node-topology-config/topologyConfig.yaml: no such file or directory"**
time="2022-05-13T07:53:28Z" level=info msg="Successfully started the lock request handler"
time="2022-05-13T07:53:28Z" level=warning msg=**"continuing with default topology keys"**
time="2022-05-13T07:53:28Z" level=debug msg="setting GrpcMaxThreads to 50"
time="2022-05-13T07:53:28Z" level=debug msg="Entering nodeProbe"
time="2022-05-13T07:53:28Z" level=info msg="CleanupMapEntries: Successfully started the cleanup worker. This will wake up every 240.00 minutes to clean up stale entries"
time="2022-05-13T07:54:00Z" level=debug msg="Exiting nodeProbe"
time="2022-05-13T07:54:00Z" level=error msg="Cannot read directory: /sys/class/fc_host" error="open /sys/class/fc_host: no such file or directory"
time="2022-05-13T07:54:00Z" level=error msg="nodeStartup could not GetFCHostPortWWNs"
time="2022-05-13T07:54:00Z" level=info msg="TransportProtocol FC portWWNs: [] ... IQNs: [iqn.1993-08.org.debian:01:af5bf2af356]"
time="2022-05-13T07:54:00Z" level=debug msg="GetSymmetrixIDList returned: [000197902417]"
time="2022-05-13T07:54:00Z" level=info msg="**************************nodeHostSetupexecuting...*******************************"_