### PR TITLE
Ability to configure mulitple NS in a single SRDF Metro RDFg

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -1092,7 +1092,7 @@ func (s *service) verifyProtectionGroupID(ctx context.Context, symID, storageGro
 	}
 	for _, value := range sgList.StorageGroupIDs {
 		// Is it trying to create more than one SG in async mode for one rdf group
-		if (repMode == Async || repMode == Metro) &&
+		if (repMode == Async) &&
 			(strings.Contains(value, "-"+localRdfGrpNo+"-"+Async) || strings.Contains(value, "-"+localRdfGrpNo+"-"+Sync) || strings.Contains(value, "-"+localRdfGrpNo+"-"+Metro)) {
 			return fmt.Errorf("RDF group (%s) is already a part of ReplicationGroup (%s) in Sync/Async/Metro mode", localRdfGrpNo, value)
 		}
@@ -1100,6 +1100,11 @@ func (s *service) verifyProtectionGroupID(ctx context.Context, symID, storageGro
 		// Is it trying to create a SG with a rdf group which is already used in Async/Metro mode
 		if repMode == Sync && (strings.Contains(value, "-"+localRdfGrpNo+"-"+Async) || strings.Contains(value, "-"+localRdfGrpNo+"-"+Metro)) {
 			return fmt.Errorf("RDF group (%s) is already part of another Async/Metro mode ReplicationGroup (%s)", localRdfGrpNo, value)
+		}
+
+		// Is it trying to create a SG with a rdf group which is already used in Async/Sync mode
+		if repMode == Metro && (strings.Contains(value, "-"+localRdfGrpNo+"-"+Async) || strings.Contains(value, "-"+localRdfGrpNo+"-"+Sync)) {
+			return fmt.Errorf("RDF group (%s) is already part of another Async/Sync mode ReplicationGroup (%s)", localRdfGrpNo, value)
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description
* Added support to confiugre muliple NS to single Metro RDFg
* Modified delete_worker.go to issue suspend of the Metro RDFg only when a single RDF LUN exists in that group.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/303|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Cluster Tests
