### PR TITLE
[305]: OCP 4.10 validation udpated

### DIFF
--- a/dell-csi-helm-installer/verify.sh
+++ b/dell-csi-helm-installer/verify.sh
@@ -224,7 +224,7 @@ function verify_openshift_versions() {
   log arrow
   log smart_step "Verifying minimum OpenShift version" "small"
   error=0
-  if [[ ${V} < ${MIN} ]]; then
+  if (( ${V%%.*} < ${MIN%%.*} || ( ${V%%.*} == ${MIN%%.*} && ${V##*.} < ${MIN##*.} ) )) ; then
     error=1
     found_error "OpenShift version ${V} is too old. Minimum required version is: ${MIN}"
   fi
@@ -234,7 +234,7 @@ function verify_openshift_versions() {
   log arrow
   log smart_step "Verifying maximum OpenShift version" "small"
   error=0
-  if [[ ${V} > ${MAX} ]]; then
+  if (( ${V%%.*} > ${MAX%%.*} || ( ${V%%.*} == ${MAX%%.*} && ${V##*.} > ${MAX##*.} ) )) ; then
     error=1
     found_warning "OpenShift version ${V} is newer than the version that has been tested. Latest tested version is: ${MAX}"
   fi


### PR DESCRIPTION
# Description
As part of OCP 4.10 support for csi-unity driver , fixed verify script which validates MIN and MAX versions of Openshift supported by the driver

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/305 |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please refer PR https://github.com/dell/csi-unity/pull/87 for screenshots
