### PR TITLE
Update Authorization Sidecar image to 1.3.0

### DIFF
--- a/helm/csi-powermax/values.yaml
+++ b/helm/csi-powermax/values.yaml
@@ -424,8 +424,8 @@ migration:
 authorization:
   enabled: false
   # sidecarProxyImage: the container image used for the csm-authorization-sidecar.
-  # Default value: dellemc/csm-authorization-sidecar:v1.2.0
-  sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.2.0
+  # Default value: dellemc/csm-authorization-sidecar:v1.3.0
+  sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.3.0
   # proxyHost: hostname of the csm-authorization server
   # Default value: None
   proxyHost:


### PR DESCRIPTION
# Description
This PR updates CSM authorization sidecar to the latest 1.3.0 image. This version change addresses a new rule added to gosec that detects if ReadHeaderTimeout is configured in the http.Server for the sidecar.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/346 |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
