### PR TITLE
Enhances concurrent CreateVolume requests for SRDF volumes

### DIFF
--- a/service/replication.go
+++ b/service/replication.go
@@ -75,7 +75,7 @@ func (s *service) ProtectStorageGroup(ctx context.Context, symID, remoteSymID, s
 	if rdfg.Async && rdfg.NumDevices > 0 {
 		return status.Errorf(codes.Internal, "RDF group (%s) cannot be used for ASYNC, as it already has volume pairing", rdfGrpNo)
 	}
-	log.Debugf("RDF: rdfg has 0 device ! vol(%s)", localVolID)
+	log.Debugf("RDF: rdfg has %d devices ! for vol(%s)", rdfg.NumDevices, localVolID)
 	err = s.verifyAndDeleteRemoteStorageGroup(ctx, remoteSymID, remoteStorageGroupName, pmaxClient)
 	if err != nil {
 		log.Error(fmt.Sprintf("Could not verify remote storage group (%s)", storageGroupName))
@@ -609,4 +609,17 @@ func validateRDFState(ctx context.Context, symID, action, sgName, rdfGrpNo strin
 func buildProtectionGroupID(namespace, localRdfGrpNo, repMode string) string {
 	protectionGrpID := CsiRepSGPrefix + namespace + "-" + localRdfGrpNo + "-" + repMode
 	return protectionGrpID
+}
+
+func (s *service) addVolumesToProtectedStorageGroup(ctx context.Context, reqID, symID, localProtectionGroupID, remoteSymID, remoteProtectionGroupID string, force bool, volID string, pmaxClient pmax.Pmax) error {
+	lockHandle := fmt.Sprintf("%s%s", localProtectionGroupID, symID)
+	lockNum := RequestLock(lockHandle, reqID)
+	defer ReleaseLock(lockHandle, reqID, lockNum)
+	err := pmaxClient.AddVolumesToProtectedStorageGroup(ctx, symID, localProtectionGroupID, remoteSymID, remoteProtectionGroupID, false, volID)
+	if err != nil {
+		log.Error(fmt.Sprintf("Could not add volume in protected SG: %s: %s", volID, err.Error()))
+		return status.Errorf(codes.Internal, "Could not add volume in protected SG: %s: %s", volID, err.Error())
+	}
+	log.Debugf("volume (%s) added to protected SG (%s)", volID, localProtectionGroupID)
+	return nil
 }


### PR DESCRIPTION
# Description
- Enhances concurrency for a large number of creating replicated volumes calls.
- Adds additional locks.
- Adds a rollback for the latest volume when the SRDF group becomes non-RDF.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/550 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- Unit Tests
- Cluster Tests