### PR TITLE
Upgrades CreateVolume to Rollback on a failure

### DIFF
--- a/service/deletion_worker.go
+++ b/service/deletion_worker.go
@@ -490,9 +490,9 @@ func (queue *deletionQueue) removeVolumesFromStorageGroup(pmaxClient pmax.Pmax) 
 				log.Errorf("GetRDFGroup failed for (%s) on symID (%s)", sgID, queue.SymID)
 				return false
 			}
-			// PMAX fails the delete of the last volume in a Metro RDFg if
-			// the RDFg is not suspended. So allow Suspend only if its the last volume in the RDFg
-			if (mode == Metro) && (rdfInfo.NumDevices == 1) {
+			// PMAX fails to delete the last volume in a Metro RDFg if
+			// the RDFg is not suspended. So allow the "Suspend" only if it's the last volume in the RDFg
+			if (mode == Metro) && (rdfInfo.NumDevices == 1 || rdfInfo.NumDevices == len(volumeIDs)) {
 				state := psg.States[0]
 				if state != Suspended {
 					//SUSPEND the protected storage group


### PR DESCRIPTION
# Description
A few sentences describing the overall goals of the pull request's commits.
- Upgrades CreateVolume call to roll back the last added volume in the protected storage group.
- Updated Metro volume deletion to suspend if all the volumes are removed at once

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/561|
| https://github.com/dell/csm/issues/552 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- Unit tests
- Cluster tests