### PR TITLE
Updates the return message in DeleteSnapshot for non existing snaps 

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -2935,9 +2935,9 @@ func (s *service) DeleteSnapshot(
 	// Idempotency check
 	snapInfo, err := pmaxClient.GetSnapshotInfo(ctx, symID, devID, snapID)
 	if err != nil {
-		//Unisphere returns "does not exist"
-		//when the snapshot is not found for Elm-SR ucode(9.0)
-		if strings.Contains(err.Error(), "does not exist") {
+		//Unisphere returns "not found"
+		//when the snapshot is not found for Juniper ucode(10.0)
+		if strings.Contains(err.Error(), "not found") {
 			return &csi.DeleteSnapshotResponse{}, nil
 		}
 		// Snapshot to be deleted couldn't be found in the system.


### PR DESCRIPTION
# Description
- Updates the return message in DeleteSnapshot for nonexisting snaps.
- The new error msg is based on Powermax 10.0 API response

# GitHub Issues
List the GitHub issues impacted by this PR:
| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/593|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- Unit Test
  - 544 scenarios (544 passed)
3865 steps (3865 passed)
- Cluster Test