### PR TITLE
Enable CSI snapshot restore to Metro Volumes

### DIFF
--- a/service/replication.go
+++ b/service/replication.go
@@ -745,12 +745,12 @@ func validateRDFState(ctx context.Context, symID, action, sgName, rdfGrpNo strin
 	state := psg.States[0]
 	switch action {
 	case Resume:
-		if state == Consistent {
+		if state == Consistent || state == Synchronized || state == ActiveBias {
 			log.Infof("SG (%s) is already in desired state: (%s)", sgName, state)
 			return true, nil
 		}
 	case Establish:
-		if state == Consistent {
+		if state == Consistent || state == Synchronized || state == ActiveBias {
 			log.Infof("SG (%s) is already in desired state: (%s)", sgName, state)
 			return true, nil
 		}


### PR DESCRIPTION
# Description
- Adds feature to create metro volumes from a snapshot
- Adds suspend/resume for SRDF SGs to enable linking of snapshots to newly created SRDF vols.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/609 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- Unit test
  552 scenarios (552 passed)  
  3896 steps (3896 passed) PASS ok
- Cluster test