### PR TITLE
Update step_defs_test.go

### DIFF
--- a/test/integration/step_defs_test.go
+++ b/test/integration/step_defs_test.go
@@ -496,6 +496,7 @@ func (f *feature) getMountVolumeRequest(name string) *csi.CreateVolumeRequest {
 	params := make(map[string]string)
 	params[service.SymmetrixIDParam] = f.symID
 	params[service.ServiceLevelParam] = f.serviceLevel
+	params[service.CSIPVCNamespace] = "INT"
 	params[service.StoragePoolParam] = f.srpID
 	req.Parameters = params
 	now := time.Now()


### PR DESCRIPTION
Added the line "params[service.CSIPVCNamespace] = "INT"" at line number 499 to overcome the runtime error (slice bounds out of range [:2])

# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
