### PR TITLE
Updates vCenter cred to use a Secret

### DIFF
--- a/helm/csi-powermax/templates/controller.yaml
+++ b/helm/csi-powermax/templates/controller.yaml
@@ -417,9 +417,15 @@ spec:
             - name: X_CSI_VCENTER_HOST
               value: {{ required "Must provide host url for vsphere" .Values.vSphere.vCenterHost }}
             - name: X_CSI_VCENTER_USERNAME
-              value: {{ required "Must provide username for vsphere" .Values.vSphere.vCenterUserName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.vSphere.vCenterCredSecret }}
+                  key: username
             - name: X_CSI_VCENTER_PWD
-              value: {{ required "Must provide password for vsphere" .Values.vSphere.vCenterPassword }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.vSphere.vCenterCredSecret }}
+                  key: password
             {{- end }}
           volumeMounts:
             - name: socket-dir

--- a/helm/csi-powermax/templates/node.yaml
+++ b/helm/csi-powermax/templates/node.yaml
@@ -205,9 +205,15 @@ spec:
             - name: X_CSI_VCENTER_HOST
               value: {{ required "Must provide hosr url for vsphere" .Values.vSphere.vCenterHost }}
             - name: X_CSI_VCENTER_USERNAME
-              value: {{ required "Must provide username for vsphere" .Values.vSphere.vCenterUserName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.vSphere.vCenterCredSecret }}
+                  key: username
             - name: X_CSI_VCENTER_PWD
-              value: {{ required "Must provide password for vsphere" .Values.vSphere.vCenterPassword }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.vSphere.vCenterCredSecret }}
+                  key: password
             {{- end }}
           volumeMounts:
             - name: driver-path

--- a/helm/csi-powermax/values.yaml
+++ b/helm/csi-powermax/values.yaml
@@ -428,7 +428,5 @@ vSphere:
   fcHostName: "csi-vsphere-VC-HN"
   # vCenterHost: URL/endpoint of the vCenter where all the ESX are present
   vCenterHost: "00.000.000.00"
-  # vCenterUserName: username from the vCenter credentials
-  vCenterUserName: "user"
-  # vCenterPassword: password from the vCenter credentials
-  vCenterPassword: "pwd"
+  # vCenterCredSecret: secret name for the vCenter credentials
+  vCenterCredSecret: vcenter-creds

--- a/samples/secret/vcenter-secret.yaml
+++ b/samples/secret/vcenter-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vcenter-creds
+  namespace: powermax
+type: Opaque
+data:
+  # set username to the base64 encoded username of vCenter
+  username: bm90X3RoZV91c2VybmFtZQ==
+  # set password to the base64 encoded password of vCenter
+  password: bm90X3RoZV9wYXNzd29yZA==


### PR DESCRIPTION
# Description
1. Updates the values file to take in a secret name to be used as vCenter cred.
2. Adds a sample secret to be created before using the vSphere feature.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/686 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- Cluster Test