### PR TITLE
Feature: Setting up Qos/HostIOLimits on the storage group via storage class

### DIFF
--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -31,6 +31,8 @@ const (
 	CsiVolumePrefix = "csi-"
 	//Synchronized to be used for migration state check
 	Synchronized = "Synchronized"
+	//HostLimits to be used in SG payload
+	HostLimits = "hostLimits"
 )
 
 // ResetCache resets all the maps being used with migration
@@ -143,8 +145,15 @@ func StorageGroupMigration(ctx context.Context, symID, remoteSymID, clusterPrefi
 			// get local SG Params
 			sg, err := pmaxClient.GetStorageGroup(ctx, symID, localSGID)
 			// create SG on remote SG
+			hostLimitsParam := types.SetHostIOLimitsParam{
+				HostIOLimitMBSec:    sg.HostIOLimit.HostIOLimitMBSec,
+				HostIOLimitIOSec:    sg.HostIOLimit.HostIOLimitIOSec,
+				DynamicDistribution: sg.HostIOLimit.DynamicDistribution,
+			}
+			optionalPayload := make(map[string]interface{})
+			optionalPayload[HostLimits] = hostLimitsParam
 			_, err = pmaxClient.CreateStorageGroup(ctx, remoteSymID, localSGID, sg.SRP,
-				sg.SLO, true, nil)
+				sg.SLO, true, optionalPayload)
 			if err != nil {
 				log.Error("Error creating storage group on remote array: " + err.Error())
 				return false, status.Errorf(codes.Internal, "Error creating storage group on remote array: %s", err.Error())

--- a/samples/storageclass/powermax.yaml
+++ b/samples/storageclass/powermax.yaml
@@ -41,6 +41,24 @@ parameters:
   # Optional: true, Default value: None
   # Examples: APP, app, sanity, tests
   ApplicationPrefix: <application prefix>
+  # Following params are for HostLimits, set them only if you want to set IOLimits
+  # HostLimitName uniquely identifies given set of limits on a storage class
+  # This is used in naming storage group, max of 3 letter
+  # Optional: true
+  # Example: "HL1", "HL2"
+  #HostLimitName: "HL1"
+  # The MBs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitMBSec: ""
+  # The IOs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitIOSec: ""
+  # distribution of the Host IO limits for the storage class
+  # Optional: true, Default: ""
+  # Allowed values: Never","Always" or "OnFailure" only
+  #DynamicDistribution: ""
 # If using custom driver name, change the following to point to the custom name
 # Optional: true, Default value: csi-powermax.dellemc.com
 # Examples: "csi-driver-powermax", "csi-powermax.dellemc.com"

--- a/samples/storageclass/powermax_fc.yaml
+++ b/samples/storageclass/powermax_fc.yaml
@@ -33,6 +33,24 @@ parameters:
   # Optional: true, Default value: Optimized
   # Examples: "Diamond" , "Bronze"
   ServiceLevel: <Service Level>
+  # Following params are for HostLimits, set them only if you want to set IOLimits
+  # HostLimitName uniquely identifies given set of limits on a storage class
+  # This is used in naming storage group, max of 3 letter
+  # Optional: true
+  # Example: "HL1", "HL2"
+  #HostLimitName: "HL1"
+  # The MBs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitMBSec: ""
+  # The IOs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitIOSec: ""
+  # distribution of the Host IO limits for the storage class
+  # Optional: true, Default: ""
+  # Allowed values: Never","Always" or "OnFailure" only
+  #DynamicDistribution: ""
 # If using custom driver name, change the following to point to the custom name
 # Optional: true, Default value: csi-powermax.dellemc.com
 # Examples: "csi-driver-powermax", "csi-powermax.dellemc.com"

--- a/samples/storageclass/powermax_iscsi.yaml
+++ b/samples/storageclass/powermax_iscsi.yaml
@@ -33,6 +33,24 @@ parameters:
   # Optional: true, Default value: Optimized
   # Examples: "Diamond" , "Bronze"
   ServiceLevel: <Service Level>
+  # Following params are for HostLimits, set them only if you want to set IOLimits
+  # HostLimitName uniquely identifies given set of limits on a storage class
+  # This is used in naming storage group, max of 3 letter
+  # Optional: true
+  # Example: "HL1", "HL2"
+  #HostLimitName: "HL1"
+  # The MBs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitMBSec: ""
+  # The IOs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitIOSec: ""
+  # distribution of the Host IO limits for the storage class
+  # Optional: true, Default: ""
+  # Allowed values: Never","Always" or "OnFailure" only
+  #DynamicDistribution: ""
 # If using custom driver name, change the following to point to the custom name
 # Optional: true, Default value: csi-powermax.dellemc.com
 # Examples: "csi-driver-powermax", "csi-powermax.dellemc.com"

--- a/samples/storageclass/powermax_srdf.yaml
+++ b/samples/storageclass/powermax_srdf.yaml
@@ -46,6 +46,24 @@ parameters:
   # Optional: true, Default value: Optimized
   # Examples: "Diamond" , "Bronze"
   ServiceLevel: <Service Level>
+  # Following params are for HostLimits, set them only if you want to set IOLimits
+  # HostLimitName uniquely identifies given set of limits on a storage class
+  # This is used in naming storage group, max of 3 letter
+  # Optional: true
+  # Example: "HL1", "HL2"
+  #HostLimitName: "HL1"
+  # The MBs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitMBSec: ""
+  # The IOs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitIOSec: ""
+  # distribution of the Host IO limits for the storage class
+  # Optional: true, Default: ""
+  # Allowed values: Never","Always" or "OnFailure" only
+  #DynamicDistribution: ""
   ########################
   # CSM module attributes
   # ######################

--- a/samples/storageclass/powermax_vsphere.yaml
+++ b/samples/storageclass/powermax_vsphere.yaml
@@ -33,6 +33,24 @@ parameters:
   # Optional: true, Default value: Optimized
   # Examples: "Diamond" , "Bronze"
   ServiceLevel: <Service Level>
+  # Following params are for HostLimits, set them only if you want to set IOLimits
+  # HostLimitName uniquely identifies given set of limits on a storage class
+  # This is used in naming storage group, max of 3 letter
+  # Optional: true
+  # Example: "HL1", "HL2"
+  #HostLimitName: "HL1"
+  # The MBs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitMBSec: ""
+  # The IOs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitIOSec: ""
+  # distribution of the Host IO limits for the storage class
+  # Optional: true, Default: ""
+  # Allowed values: Never","Always" or "OnFailure" only
+  #DynamicDistribution: ""
 # If using custom driver name, change the following to point to the custom name
 # Optional: true, Default value: csi-powermax.dellemc.com
 # Examples: "csi-driver-powermax", "csi-powermax.dellemc.com"

--- a/samples/storageclass/powermax_xfs.yaml
+++ b/samples/storageclass/powermax_xfs.yaml
@@ -29,6 +29,24 @@ parameters:
   # Optional: true, Default value: Optimized
   # Examples: "Diamond" , "Bronze"
   ServiceLevel: <Service Level>
+  # Following params are for HostLimits, set them only if you want to set IOLimits
+  # HostLimitName uniquely identifies given set of limits on a storage class
+  # This is used in naming storage group, max of 3 letter
+  # Optional: true
+  # Example: "HL1", "HL2"
+  #HostLimitName: "HL1"
+  # The MBs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitMBSec: ""
+  # The IOs per Second Host IO limit for the storage class
+  # Optional: true, Default: ""
+  # Examples: 100, 200, NOLIMIT
+  #HostIOLimitIOSec: ""
+  # distribution of the Host IO limits for the storage class
+  # Optional: true, Default: ""
+  # Allowed values: Never","Always" or "OnFailure" only
+  #DynamicDistribution: ""
 # If using custom driver name, change the following to point to the custom name
 # Optional: true, Default value: csi-powermax.dellemc.com
 # Examples: "csi-driver-powermax", "csi-powermax.dellemc.com"

--- a/service/controller.go
+++ b/service/controller.go
@@ -99,6 +99,11 @@ const (
 	SyncInProgress                  = "SyncInProg"
 	Vsphere                         = "VSPHERE"
 	MigrationActionCommit           = "Commit"
+	HostLimitName                   = "HostLimitName"
+	HostLimits                      = "hostLimits"
+	HostIOLimitMBSec                = "HostIOLimitMBSec"
+	HostIOLimitIOSec                = "HostIOLimitIOSec"
+	DynamicDistribution             = "DynamicDistribution"
 )
 
 // Keys for parameters to CreateVolume
@@ -327,13 +332,31 @@ func (s *service) CreateVolume(
 		storageGroupName = params[StorageGroupParam]
 	}
 
+	// get HostIOLimits for the storage group
+	hostLimitName := ""
+	hostMBsec := ""
+	hostIOsec := ""
+	hostDynDistribution := ""
+	if params[HostLimitName] != "" {
+		hostLimitName = params[HostLimitName]
+	}
+	if params[HostIOLimitMBSec] != "" {
+		hostMBsec = params[HostIOLimitMBSec]
+	}
+	if params[HostIOLimitIOSec] != "" {
+		hostIOsec = params[HostIOLimitIOSec]
+	}
+	if params[DynamicDistribution] != "" {
+		hostDynDistribution = params[DynamicDistribution]
+	}
+
 	// Get the namespace
 	namespace := ""
 	if params[CSIPVCNamespace] != "" {
 		namespace = params[CSIPVCNamespace]
 	}
 
-	// Remote Replication based params
+	// Remote Replication based paramsMes
 	var replicationEnabled string
 	var remoteSymID string
 	var localRDFGrpNo string
@@ -376,7 +399,7 @@ func (s *service) CreateVolume(
 			log.Debugf("RDF group for given array pair and RDF mode: local(%s), remote(%s)", localRDFGrpNo, remoteRDFGrpNo)
 		}
 		if repMode == Metro {
-			return s.createMetroVolume(ctx, req, reqID, storagePoolID, symmetrixID, storageGroupName, serviceLevel, thick, remoteSymID, localRDFGrpNo, remoteRDFGrpNo, remoteServiceLevel, remoteSRPID, namespace, applicationPrefix, bias)
+			return s.createMetroVolume(ctx, req, reqID, storagePoolID, symmetrixID, storageGroupName, serviceLevel, thick, remoteSymID, localRDFGrpNo, remoteRDFGrpNo, remoteServiceLevel, remoteSRPID, namespace, applicationPrefix, bias, hostLimitName, hostMBsec, hostIOsec, hostDynDistribution)
 		}
 		if repMode != Async && repMode != Sync {
 			log.Errorf("Unsupported Replication Mode: (%s)", repMode)
@@ -493,6 +516,9 @@ func (s *service) CreateVolume(
 			storageGroupName = fmt.Sprintf("%s-%s-%s-%s-%s-SG", CSIPrefix, s.getClusterPrefix(),
 				applicationPrefix, serviceLevel, storagePoolID)
 		}
+		if hostLimitName != "" {
+			storageGroupName = fmt.Sprintf("%s-%s", storageGroupName, hostLimitName)
+		}
 	}
 	// localProtectionGroupID refers to name of Storage Group which has protected local volumes
 	// remoteProtectionGroupID refers to name of Storage Group which has protected remote volumes
@@ -526,6 +552,9 @@ func (s *service) CreateVolume(
 		HeaderPersistentVolumeName:           params[CSIPersistentVolumeName],
 		HeaderPersistentVolumeClaimName:      params[CSIPersistentVolumeClaimName],
 		HeaderPersistentVolumeClaimNamespace: params[CSIPVCNamespace],
+		HostIOLimitMBSec:                     hostMBsec,
+		HostIOLimitIOSec:                     hostIOsec,
+		DynamicDistribution:                  hostDynDistribution,
 	}
 	log.WithFields(fields).Info("Executing CreateVolume with following fields")
 
@@ -549,10 +578,17 @@ func (s *service) CreateVolume(
 	}
 	// Check existence of the Storage Group and create if necessary.
 	sg, err := pmaxClient.GetStorageGroup(ctx, symmetrixID, storageGroupName)
+	log.Debug(fmt.Sprintf("Unable to find storage group: %s", storageGroupName))
 	if err != nil || sg == nil {
-		log.Debug(fmt.Sprintf("Unable to find storage group: %s", storageGroupName))
+		hostLimitsParam := &types.SetHostIOLimitsParam{
+			HostIOLimitMBSec:    hostIOsec,
+			HostIOLimitIOSec:    hostMBsec,
+			DynamicDistribution: hostDynDistribution,
+		}
+		optionalPayload := make(map[string]interface{})
+		optionalPayload[HostLimits] = hostLimitsParam
 		_, err := pmaxClient.CreateStorageGroup(ctx, symmetrixID, storageGroupName, storagePoolID,
-			serviceLevel, thick == "true", nil)
+			serviceLevel, thick == "true", optionalPayload)
 		if err != nil {
 			log.Error("Error creating storage group: " + err.Error())
 			return nil, status.Errorf(codes.Internal, "Error creating storage group: %s", err.Error())
@@ -778,7 +814,7 @@ func (s *service) CreateVolume(
 	return csiResp, nil
 }
 
-func (s *service) createMetroVolume(ctx context.Context, req *csi.CreateVolumeRequest, reqID, storagePoolID, symID, storageGroupName, serviceLevel, thick, remoteSymID, localRDFGrpNo, remoteRDFGrpNo, remoteServiceLevel, remoteSRPID, namespace, applicationPrefix, bias string) (*csi.CreateVolumeResponse, error) {
+func (s *service) createMetroVolume(ctx context.Context, req *csi.CreateVolumeRequest, reqID, storagePoolID, symID, storageGroupName, serviceLevel, thick, remoteSymID, localRDFGrpNo, remoteRDFGrpNo, remoteServiceLevel, remoteSRPID, namespace, applicationPrefix, bias, hostLimitName, hostMBsec, hostIOsec, hostDynDist string) (*csi.CreateVolumeResponse, error) {
 	repMode := Metro
 	accessibility := req.GetAccessibilityRequirements()
 	pmaxClient, err := s.GetPowerMaxClient(symID, remoteSymID)
@@ -908,6 +944,11 @@ func (s *service) createMetroVolume(ctx context.Context, req *csi.CreateVolumeRe
 			remoteStorageGroupName = fmt.Sprintf("%s-%s-%s-%s-%s-SG", CSIPrefix, s.getClusterPrefix(),
 				applicationPrefix, remoteServiceLevel, remoteSRPID)
 		}
+		if hostLimitName != "" {
+			storageGroupName = fmt.Sprintf("%s-%s", storageGroupName, hostLimitName)
+			remoteStorageGroupName = fmt.Sprintf("%s-%s", remoteStorageGroupName, hostLimitName)
+
+		}
 	}
 	// localProtectionGroupID refers to name of Storage Group which has protected local volumes
 	// remoteProtectionGroupID refers to name of Storage Group which has protected remote volumes
@@ -957,8 +998,16 @@ func (s *service) createMetroVolume(ctx context.Context, req *csi.CreateVolumeRe
 	sgOnR1, err := pmaxClient.GetStorageGroup(ctx, symID, storageGroupName)
 	if err != nil || sgOnR1 == nil {
 		log.Debug(fmt.Sprintf("Unable to find storage group: %s", storageGroupName))
+		hostLimitsParam := &types.SetHostIOLimitsParam{
+			HostIOLimitMBSec:    hostMBsec,
+			HostIOLimitIOSec:    hostIOsec,
+			DynamicDistribution: hostDynDist,
+		}
+		optionalPayload := make(map[string]interface{})
+		optionalPayload[HostLimits] = hostLimitsParam
+
 		_, err := pmaxClient.CreateStorageGroup(ctx, symID, storageGroupName, storagePoolID,
-			serviceLevel, thick == "true", nil)
+			serviceLevel, thick == "true", optionalPayload)
 		if err != nil {
 			log.Error("Error creating storage group on R1: " + err.Error())
 			return nil, status.Errorf(codes.Internal, "Error creating storage group: %s", err.Error())
@@ -968,8 +1017,15 @@ func (s *service) createMetroVolume(ctx context.Context, req *csi.CreateVolumeRe
 	sgOnR2, err := pmaxClient.GetStorageGroup(ctx, remoteSymID, remoteStorageGroupName)
 	if err != nil || sgOnR2 == nil {
 		log.Debug(fmt.Sprintf("Unable to find storage group: %s", remoteStorageGroupName))
+		hostLimitsParam := &types.SetHostIOLimitsParam{
+			HostIOLimitMBSec:    hostMBsec,
+			HostIOLimitIOSec:    hostIOsec,
+			DynamicDistribution: hostDynDist,
+		}
+		optionalPayload := make(map[string]interface{})
+		optionalPayload[HostLimits] = hostLimitsParam
 		_, err := pmaxClient.CreateStorageGroup(ctx, remoteSymID, remoteStorageGroupName, remoteSRPID,
-			remoteServiceLevel, thick == "true", nil)
+			remoteServiceLevel, thick == "true", optionalPayload)
 		if err != nil {
 			log.Error("Error creating storage group on R2: " + err.Error())
 			return nil, status.Errorf(codes.Internal, "Error creating storage group: %s", err.Error())
@@ -3528,8 +3584,16 @@ func (s *service) CreateRemoteVolume(ctx context.Context, req *csiext.CreateRemo
 	sg, err := pmaxClient.GetStorageGroup(ctx, remoteSymID, remoteStorageGroupName)
 	if err != nil || sg == nil {
 		log.Debug(fmt.Sprintf("Unable to find storage group: %s", remoteStorageGroupName))
+		hostLimitsParam := types.SetHostIOLimitsParam{
+			HostIOLimitMBSec:    sg.HostIOLimit.HostIOLimitMBSec,
+			HostIOLimitIOSec:    sg.HostIOLimit.HostIOLimitIOSec,
+			DynamicDistribution: sg.HostIOLimit.DynamicDistribution,
+		}
+		optionalPayload := make(map[string]interface{})
+		optionalPayload[HostLimits] = hostLimitsParam
+
 		_, err := pmaxClient.CreateStorageGroup(ctx, remoteSymID, remoteStorageGroupName, remoteSRPID,
-			remoteServiceLevel, thick == "true", nil)
+			remoteServiceLevel, thick == "true", optionalPayload)
 		if err != nil {
 			log.Errorf("Error: (%s) creating storage group on R2 (%s): ", err.Error(), remoteSymID)
 			return nil, status.Errorf(codes.Internal, "Error creating storage group: %s", err.Error())

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -718,3 +718,10 @@ Feature: PowerMax CSI interface
     | allowedList                 | deniedList                  |
     | "*-000197900046."           | "Node1-000197900047.iscsi"  |
     | "Node1-000197900046.fc"     | "*-000197900047."           |
+
+@v2.7.0
+  Scenario: Create a volume in storage group with HostIOLimits
+  Given a PowerMax service
+  And I have SetHostIOLimits on the storage group
+  And I call CreateVolume "volume1" with namespace "ns"
+  Then a valid CreateVolumeResponse is returned


### PR DESCRIPTION
# Description
- A user can use the storage class param to set IO limits on the storage group and its volumes.
- This enables throttling performance and bandwidth of CSI Volumes

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/726 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- Cluster Test