### PR TITLE
Feature storage capacity tracking

### DIFF
--- a/helm/csi-powermax/templates/_helpers.tpl
+++ b/helm/csi-powermax/templates/_helpers.tpl
@@ -48,3 +48,11 @@ Return the appropriate sidecar images based on k8s version
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "csi-powermax.isStorageCapacitySupported" -}}
+{{- if eq .Values.storageCapacity.enabled true -}}
+  {{- if and (eq .Capabilities.KubeVersion.Major "1") (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
+      {{- true -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/csi-powermax/templates/controller.yaml
+++ b/helm/csi-powermax/templates/controller.yaml
@@ -92,7 +92,19 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]  
-  {{- end}}  
+  {{- end}} 
+  # Permissions for Storage Capacity
+  {{- if eq (include "csi-powermax.isStorageCapacitySupported" .) "true" }}
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  {{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -185,9 +197,20 @@ spec:
             - "--leader-election"
             - "--extra-create-metadata"
             - "--feature-gates=Topology=true"
+            - "--enable-capacity={{ (include "csi-powermax.isStorageCapacitySupported" .) | default false }}"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval={{ .Values.storageCapacity.pollInterval | default "5m" }}"
           env:
             - name: ADDRESS
               value: /var/run/csi/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/helm/csi-powermax/templates/csidriver.yaml
+++ b/helm/csi-powermax/templates/csidriver.yaml
@@ -7,5 +7,7 @@ metadata:
     name: csi-powermax.dellemc.com
   {{- end }}
 spec:
+    podInfoOnMount: true
     attachRequired: true
+    storageCapacity: {{ (include "csi-powermax.isStorageCapacitySupported" .) | default false }}
     fsGroupPolicy: {{ .Values.fsGroupPolicy }}

--- a/helm/csi-powermax/values.yaml
+++ b/helm/csi-powermax/values.yaml
@@ -426,6 +426,20 @@ authorization:
   #   "false" - TLS certificate will be verified 
   # Default value: "true" 
   skipCertificateValidation: true
+  
+#Storage Capacity Tracking
+# Note: Capacity tracking is supported in kubernetes v1.25 and above, this feature will be automatically disabled in older versions.
+storageCapacity:
+  # enabled : Enable/Disable storage capacity tracking
+  # Allowed values:
+  #   true: enable storage capacity tracking
+  #   false: disable storage capacity tracking
+  # Default value: true
+  enabled: true
+  # pollInterval : Configure how often external-provisioner polls the driver to detect changed capacity
+  # Allowed values: 1m,2m,3m,...,10m,...,60m etc
+  # Default value: 5m
+  pollInterval: 5m
 
 # VMware/vSphere virtualization support
 # set enable to true, if you to enable VMware virtualized environment support via RDM

--- a/service/controller.go
+++ b/service/controller.go
@@ -2672,17 +2672,6 @@ func (s *service) GetCapacity(
 		return nil, err
 	}
 
-	// Optionally validate the volume capability
-	vcs := req.GetVolumeCapabilities()
-	if vcs != nil {
-		supported, reason := valVolumeCaps(vcs, nil)
-		if !supported {
-			log.Error("GetVolumeCapabilities failed with error: " + reason)
-			return nil, status.Errorf(codes.InvalidArgument, reason)
-		}
-		log.Infof("Supported capabilities - Error(%s)", reason)
-	}
-
 	// Storage (resource) Pool. Validate it against exist Pools
 	storagePoolID := params[StoragePoolParam]
 	err = s.validateStoragePoolID(ctx, symmetrixID, storagePoolID, pmaxClient)


### PR DESCRIPTION
# Description
Support storagecapacitytracking feature for PowerMax.

Additional context
This feature helps the scheduler to schedule the pod on a node (satisfying the topology constraints) only if the requested capacity is available on the storage array. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -----------------|
|https://github.com/dell/csm/issues/876|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
![image](https://github.com/dell/csi-powermax/assets/98810659/565c14ce-eb74-4da4-b2a2-0509a30acd75)
