### PR TITLE
Undated the Unit test Scenario.

### DIFF
--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -293,7 +293,7 @@ Feature: PowerMax CSI interface
      Scenario: Call GetCapacity with invalid capabilities
       Given a PowerMax service
       And I call GetCapacity with Invalid capabilities
-      Then the error contains "access mode cannot be UNKNOWN"
+      Then the error contains "A valid SRP parameter is required"
 
 @v1.0.0
      Scenario: Call ControllerGetCapabilities


### PR DESCRIPTION
Updated the Scenario: Call GetCapacity with invalid capabilities

# Description
The Unit test for the CSI-PowerMax was failing in the scenario: Call GetCapacity with invalid capabilities. Rectified the error accordingly.

# GitHub Issues
List the GitHub issues impacted by this PR: 

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/887 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Run the unit test manually and also through the automation, All the test got successfully passed. 
