### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/core/semver/semver.go
+++ b/core/semver/semver.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,7 +71,7 @@ func main() {
 		format = "ver"
 	} else {
 		if fileExists(format) {
-			buf, err := ioutil.ReadFile(format) // #nosec G304
+			buf, err := os.ReadFile(format) // #nosec G304
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: read tpl failed: %v\n", err)
 				os.Exit(1)

--- a/service/node.go
+++ b/service/node.go
@@ -17,7 +17,6 @@ package service
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path"
@@ -561,7 +560,7 @@ func (s *service) disconnectVolume(reqID, symID, devID, volumeWWN string) error 
 		time.Sleep(disconnectVolumeRetryTime)
 
 		// Check that the /sys/block/DeviceName actually exists
-		if _, err := ioutil.ReadDir(sysBlock + deviceName); err != nil {
+		if _, err := os.ReadDir(sysBlock + deviceName); err != nil {
 			// If not, make sure the symlink is removed
 			os.Remove(symlinkPath) // #nosec G20
 		}
@@ -2312,7 +2311,7 @@ func (s *service) getAndConfigureArrayISCSITargets(ctx context.Context, arrayTar
 // writeWWNFile writes a volume's WWN to a file copy on the node
 func (s *service) writeWWNFile(id, volumeWWN string) error {
 	wwnFileName := fmt.Sprintf("%s/%s.wwn", s.privDir, id)
-	err := ioutil.WriteFile(wwnFileName, []byte(volumeWWN), 0644) // #nosec G306
+	err := os.WriteFile(wwnFileName, []byte(volumeWWN), 0644) // #nosec G306
 	if err != nil {
 		return status.Errorf(codes.Internal, "Could not read WWN file: %s", wwnFileName)
 	}
@@ -2323,7 +2322,7 @@ func (s *service) writeWWNFile(id, volumeWWN string) error {
 func (s *service) readWWNFile(id string) (string, error) {
 	// READ volume WWN
 	wwnFileName := fmt.Sprintf("%s/%s.wwn", s.privDir, id)
-	wwnBytes, err := ioutil.ReadFile(wwnFileName) // #nosec G304
+	wwnBytes, err := os.ReadFile(wwnFileName) // #nosec G304
 	if err != nil {
 		return "", status.Errorf(codes.Internal, "Could not read WWN file: %s", wwnFileName)
 	}


### PR DESCRIPTION
# Description
"io/ioutil" has been deprecated since Go 1.19: As of Go 1.16

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/916 |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
