### PR TITLE
Use common base image

### DIFF
--- a/.build.config
+++ b/.build.config
@@ -22,10 +22,5 @@ UBIM:
   NAMESPACE: ubi8/ubi-minimal
   VERSION: 8.7-1085  
   SHA: ab03679e683010d485ef0399e056b09a38d7843ba4a36ee7dec337dd0037f7a7
-UBIMICRO:
-  REPO: registry.access.redhat.com
-  NAMESPACE: ubi9/ubi-micro
-  VERSION: 9.2-15
-  SHA: a54f5a7a9b67f32b6ae402cf0659ba4a3fd8eed4bdcbd00b5514ce4450b31214
 IMAGE:
   NAME: csi-powermax

--- a/build.sh
+++ b/build.sh
@@ -332,23 +332,19 @@ elif [ "$SOURCE_IMAGE_TYPE" = "ubim" ]; then
    fi
    IMAGE_TYPE="ubim"
 elif [ "$SOURCE_IMAGE_TYPE" = "ubimicro" ]; then
-   if [ -n "$UBIMICRO_SHA" ]; then
-     # We need to use the SHA
-     SOURCE_IMAGE_TAG=$UBIMICRO_SHA
-   else
-     SOURCE_IMAGE_TAG=$UBIMICRO_VERSION
-   fi   
-   IMAGE_TYPE="ubimicro"   
+   # if using ubimicro, download common CSM ubimicro image
+   curl -O -L https://raw.githubusercontent.com/dell/csm/main/config/csm-common.mk
+   source csm-common.mk
+   CSM_COMMON_BASE_IMAGE=$DEFAULT_BASEIMAGE
+   echo "Using CSM common image for ubimicro: ${CSM_COMMON_BASE_IMAGE}"
+   IMAGE_TYPE="ubimicro"
 fi
 
 build_source_image_repo_name
 
 if [ "$SOURCE_IMAGE_TYPE" = "ubimicro" ]; then
    echo "Adding driver dependencies to ubi micro image"
-   if [ -n "$UBIMICRO_SHA" ]; then
-    SOURCE_REPO="$SOURCE_REPO@sha256"
-   fi
-   bash ./buildubimicro.sh "$SOURCE_REPO:$SOURCE_IMAGE_TAG"
+   bash ./buildubimicro.sh "$CSM_COMMON_BASE_IMAGE"
    SOURCE_REPO="localhost/csipowermax-ubimicro"
    SOURCE_IMAGE_TAG="latest"
 fi 


### PR DESCRIPTION
# Description
Use common base image

If building for ubimicro, download the csm-common.mk file and use that specified UBI micro image instead of relying on the .build.config file.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1031 |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
