### PR TITLE
go version bump-up

### DIFF
--- a/csireverseproxy/go.mod
+++ b/csireverseproxy/go.mod
@@ -1,6 +1,6 @@
 module revproxy/v2
 
-go 1.21
+go 1.22
 
 require (
 	github.com/dell/gopowermax/v2 v2.5.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/csi-powermax/v2
 
-go 1.21
+go 1.22
 
 require (
 	github.com/akutz/goof v0.1.2


### PR DESCRIPTION
Updating go version to latest available i.e. => 1.22