### PR TITLE
Check for block volume first and then file

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -1695,13 +1695,11 @@ func (s *service) DeleteVolume(
 		log.Error("Failed to probe with erro: " + err.Error())
 		return nil, err
 	}
-	// Check if devID is a file system
-	_, err = pmaxClient.GetFileSystemByID(ctx, symID, devID)
+	// Check if devID is a non-fileSystem
+	_, err = pmaxClient.GetVolumeByID(ctx, symID, devID)
 	if err != nil {
-		log.Debugf("Error:(%s) fetching file system with ID %s", err.Error(), devID)
-		log.Debugf("GetfileSystem failed, continuing with GetVolumeID...")
-	} else {
-		// found file system
+		log.Debugf("Error:(%s) fetching volume with ID %s", err.Error(), devID)
+		log.Debugf("checking for fileSystem...")
 		err := s.deleteFileSystem(ctx, reqID, symID, volName, devID, id, pmaxClient)
 		if err != nil {
 			return nil, err
@@ -2467,11 +2465,10 @@ func (s *service) ControllerUnpublishVolume(
 	}
 
 	// Check if devID is a file system
-	_, err = pmaxClient.GetFileSystemByID(ctx, symID, devID)
+	_, err = pmaxClient.GetVolumeByID(ctx, symID, devID)
 	if err != nil {
-		log.Debugf("Error:(%s) fetching file system with ID %s", err.Error(), devID)
-		log.Debugf("GetfileSystem failed, continuing with GetVolumeID...")
-	} else {
+		log.Debugf("Error:(%s) fetching volume with ID %s", err.Error(), devID)
+		log.Debugf("continuing with fileSystem...")
 		// found file system
 		return file.DeleteNFSExport(ctx, reqID, symID, devID, pmaxClient)
 	}

--- a/service/features/csi_extension.feature
+++ b/service/features/csi_extension.feature
@@ -68,7 +68,6 @@ Feature: PowerMax CSI interface
       | "none"                    | "no IOInProgress"  |
       | "InvalidSymID"            | "not found"        |
       | "GetArrayPerfKeyError"    | "getting keys"     |
-      | "GetVolumesMetricsError"  | "error"            |
       | "GetFreshMetrics"         | "none"             |
 
   @resiliency
@@ -83,4 +82,24 @@ Feature: PowerMax CSI interface
     Examples:
       | induced                   | error             |
       | "none"                    | "no IOInProgress" |
-      | "GetFileSysMetricsError"  | "error"           |
+
+  @resiliency
+  @v2.11.0
+  Scenario: call IsIOInProgress and get fileSystem metric
+    Given a PowerMax service
+    And I call fileSystem CreateVolume "volume1"
+    Then a valid CreateVolumeResponse is returned
+    And I induce error "GetVolumesMetricsError"
+    When I call IsIOInProgress
+    Then the error contains "no IOInProgress"
+
+  @resiliency
+  @v2.11.0
+  Scenario: call IsIOInProgress and get Metric error
+    Given a PowerMax service
+    And I call fileSystem CreateVolume "volume1"
+    Then a valid CreateVolumeResponse is returned
+    And I induce error "GetFileSysMetricsError"
+    And I induce error "GetVolumesMetricsError"
+    When I call IsIOInProgress
+    Then the error contains "error"      

--- a/service/features/delete_volume.feature
+++ b/service/features/delete_volume.feature
@@ -89,7 +89,7 @@ Feature: PowerMax CSI interface
       | "InvalidVolumeID"      | "Could not parse"              |
       | "UpdateVolumeError"    | "Failed to rename volume"      |
       | "GetStorageGroupError" | "Unable to find storage group" |
-      | "GetVolumeError"       | "Could not retrieve volume"    |
+      | "GetVolumeError"       | "cannot be found"              |
 
   @delete
   @v1.0.0


### PR DESCRIPTION
# Description
- For improving performance, we reverse the order to check block volume first and then file.
- Updated unit tests

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1370|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- Cluster Test
- Unit Test