### PR TITLE
Rearrange Protocol preferences for its automatic selection

### DIFF
--- a/csireverseproxy/pkg/standaloneproxy/standaloneproxy.go
+++ b/csireverseproxy/pkg/standaloneproxy/standaloneproxy.go
@@ -106,7 +106,6 @@ func newReverseProxy(mgmtServer config.ManagementServer) common.Proxy {
 }
 
 func newTLSConfig(mgmtServer config.ManagementServer) *tls.Config {
-
 	tlsConfig := tls.Config{
 		InsecureSkipVerify: mgmtServer.SkipCertificateValidation, // #nosec G402 InsecureSkipVerify cannot be false always as expected by gosec, this needs to be configurable
 	}


### PR DESCRIPTION
# Description
This PR:
- Rearrange Protocol Preference for automatic selection
- NVMeTCP > FC > ISCSI
- Selects NVMeTCP or FC over iscsi if iSCSI initiators are also present on the host.

# GitHub Issues
List the GitHub issues impacted by this PR:
| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1388|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
- [x] Cluster Test
- [x] Unit Test 