### PR TITLE
[feature-1281]: Use volume identifier from array response to support Authorization v2

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -662,8 +662,8 @@ func (s *service) CreateVolume(
 			return nil, status.Errorf(codes.Internal, "Error fetching volume for idempotence check: %s", err.Error())
 		}
 		if len(vol.StorageGroupIDList) < 1 {
-			log.Error("Idempotence check: StorageGroupIDList is empty for volume ", volumeID)
-			return nil, status.Errorf(codes.Internal, "Idempotence check: StorageGroupIDList is empty for (%s): ", volumeID)
+			log.Error("Idempotence check: StorageGroupIDList is empty for (%s): " + volumeID)
+			return nil, status.Errorf(codes.Internal, "Idempotence check: StorageGroupIDList is empty for (%s)", volumeID)
 		}
 		matchesStorageGroup := false
 		for _, sgid := range vol.StorageGroupIDList {
@@ -1110,8 +1110,8 @@ func (s *service) createMetroVolume(ctx context.Context, req *csi.CreateVolumeRe
 			return nil, status.Errorf(codes.Internal, "Error fetching volume for idempotence check: %s", err.Error())
 		}
 		if len(vol.StorageGroupIDList) < 1 {
-			log.Error("Idempotence check: StorageGroupIDList is empty for volume ", volumeID)
-			return nil, status.Errorf(codes.Internal, "Idempotence check: StorageGroupIDList is empty for (%s): ", volumeID)
+			log.Error("Idempotence check: StorageGroupIDList is empty for (%s): " + volumeID)
+			return nil, status.Errorf(codes.Internal, "Idempotence check: StorageGroupIDList is empty for (%s)", volumeID)
 		}
 		matchesStorageGroup := false
 		for _, sgid := range vol.StorageGroupIDList {

--- a/service/controller.go
+++ b/service/controller.go
@@ -672,8 +672,16 @@ func (s *service) CreateVolume(
 			}
 		}
 
-		// with Authorization, how do we do this check? volumeIdentifier must have tenant prefix
-		if matchesStorageGroup && vol.VolumeIdentifier == volumeIdentifier {
+		// with Authorization, a tenant prefix is applied to the volume identifier on the array
+		// csi-CSM-pmax-69298b3d3d-namespace -> tn1-csi-CSM-pmax-69298b3d3d-namespace
+		// this prefix is stripped from the array volume identifier to compare with the locally defined volume identifier
+		var strippedTenantVolumeIdentifier string
+		if len(vol.VolumeIdentifier) >= 4 {
+			strippedTenantVolumeIdentifier = vol.VolumeIdentifier[4:]
+		}
+
+		if matchesStorageGroup && (vol.VolumeIdentifier == volumeIdentifier || strippedTenantVolumeIdentifier == volumeIdentifier) {
+			// A volume with the same name exists and has the same size
 			if vol.CapacityCYL != requiredCylinders {
 				log.Error("A volume with the same name exists but has a different size than required.")
 				alreadyExists = true

--- a/service/controller.go
+++ b/service/controller.go
@@ -713,8 +713,7 @@ func (s *service) CreateVolume(
 			}
 
 			log.WithFields(fields).Info("Idempotent volume detected, returning success")
-			// with Authorization, how do we do this check? volumeIdentifier = vol.VolumeIdentifier?
-			vol.VolumeID = fmt.Sprintf("%s-%s-%s", volumeIdentifier, symmetrixID, vol.VolumeID)
+			vol.VolumeID = fmt.Sprintf("%s-%s-%s", vol.VolumeIdentifier, symmetrixID, vol.VolumeID)
 			volResp := s.getCSIVolume(vol)
 			// Set the volume context
 			attributes := map[string]string{

--- a/service/controller.go
+++ b/service/controller.go
@@ -671,6 +671,8 @@ func (s *service) CreateVolume(
 				matchesStorageGroup = true
 			}
 		}
+
+		// with Authorization, how do we do this check? volumeIdentifier must have tenant prefix
 		if matchesStorageGroup && vol.VolumeIdentifier == volumeIdentifier {
 			if vol.CapacityCYL != requiredCylinders {
 				log.Error("A volume with the same name exists but has a different size than required.")
@@ -711,6 +713,7 @@ func (s *service) CreateVolume(
 			}
 
 			log.WithFields(fields).Info("Idempotent volume detected, returning success")
+			// with Authorization, how do we do this check? volumeIdentifier = vol.VolumeIdentifier?
 			vol.VolumeID = fmt.Sprintf("%s-%s-%s", volumeIdentifier, symmetrixID, vol.VolumeID)
 			volResp := s.getCSIVolume(vol)
 			// Set the volume context
@@ -823,7 +826,7 @@ func (s *service) CreateVolume(
 
 	// Formulate the return response
 	volID := vol.VolumeID
-	vol.VolumeID = fmt.Sprintf("%s-%s-%s", volumeIdentifier, symmetrixID, vol.VolumeID)
+	vol.VolumeID = fmt.Sprintf("%s-%s-%s", vol.VolumeIdentifier, symmetrixID, vol.VolumeID)
 	volResp := s.getCSIVolume(vol)
 	volResp.ContentSource = contentSource
 	// Set the volume context

--- a/service/controller.go
+++ b/service/controller.go
@@ -827,8 +827,8 @@ func (s *service) CreateVolume(
 	}
 
 	// Formulate the return response
-	volID := vol.VolumeID
 	vol.VolumeID = fmt.Sprintf("%s-%s-%s", vol.VolumeIdentifier, symmetrixID, vol.VolumeID)
+	volID := vol.VolumeID
 	volResp := s.getCSIVolume(vol)
 	volResp.ContentSource = contentSource
 	// Set the volume context

--- a/service/controller.go
+++ b/service/controller.go
@@ -674,13 +674,8 @@ func (s *service) CreateVolume(
 
 		// with Authorization, a tenant prefix is applied to the volume identifier on the array
 		// csi-CSM-pmax-69298b3d3d-namespace -> tn1-csi-CSM-pmax-69298b3d3d-namespace
-		// this prefix is stripped from the array volume identifier to compare with the locally defined volume identifier
-		var strippedTenantVolumeIdentifier string
-		if len(vol.VolumeIdentifier) >= 4 {
-			strippedTenantVolumeIdentifier = vol.VolumeIdentifier[4:]
-		}
-
-		if matchesStorageGroup && (vol.VolumeIdentifier == volumeIdentifier || strippedTenantVolumeIdentifier == volumeIdentifier) {
+		// since we don't know the tenant prefix, the volume identifier on the array is checked to contain the standard volume identifier
+		if matchesStorageGroup && (vol.VolumeIdentifier == volumeIdentifier || strings.Contains(vol.VolumeIdentifier, volumeIdentifier)) {
 			// A volume with the same name exists and has the same size
 			if vol.CapacityCYL != requiredCylinders {
 				log.Error("A volume with the same name exists but has a different size than required.")

--- a/service/controller.go
+++ b/service/controller.go
@@ -827,8 +827,8 @@ func (s *service) CreateVolume(
 	}
 
 	// Formulate the return response
-	vol.VolumeID = fmt.Sprintf("%s-%s-%s", vol.VolumeIdentifier, symmetrixID, vol.VolumeID)
 	volID := vol.VolumeID
+	vol.VolumeID = fmt.Sprintf("%s-%s-%s", vol.VolumeIdentifier, symmetrixID, vol.VolumeID)
 	volResp := s.getCSIVolume(vol)
 	volResp.ContentSource = contentSource
 	// Set the volume context


### PR DESCRIPTION
# Description

To support volumes with tenant prefixes with Authorization v2, the volume flows should use the volume identifier from the array..

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1281|

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
