### PR TITLE
Bugfix/link volume to volume

### DIFF
--- a/csireverseproxy/main_test.go
+++ b/csireverseproxy/main_test.go
@@ -450,4 +450,13 @@ func TestSAHTTPRequest(t *testing.T) {
 		return
 	}
 	fmt.Printf("RESPONSE_BODY: %s\n", resp)
+
+	path = utils.PrivatePrefix + "/91/sloprovisioning/symmetrix/" + storageArrayID
+	resp, err = doHTTPRequest(standAloneServer.Port, path)
+	log.Info("test info is there")
+	if err != nil {
+		t.Error(err.Error())
+		return
+	}
+	fmt.Printf("RESPONSE_BODY: %s\n", resp)
 }

--- a/csireverseproxy/pkg/standaloneproxy/standaloneproxy.go
+++ b/csireverseproxy/pkg/standaloneproxy/standaloneproxy.go
@@ -29,6 +29,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"revproxy/v2/pkg/cache"
 	"revproxy/v2/pkg/common"
 	"revproxy/v2/pkg/config"
 	"revproxy/v2/pkg/utils"
@@ -37,7 +38,6 @@ import (
 
 	types "github.com/dell/gopowermax/v2/types/v100"
 	"github.com/gorilla/mux"
-	"revproxy/v2/pkg/cache"
 )
 
 const clientSymID = "proxyClientSymID"
@@ -382,6 +382,7 @@ func (revProxy *StandAloneProxy) GetRouter() http.Handler {
 	router.PathPrefix(utils.Prefix + "/{version}/system/symmetrix/{symid}").HandlerFunc(revProxy.ServeReverseProxy)
 	router.PathPrefix(utils.Prefix + "/{version}/sloprovisioning/symmetrix/{symid}").HandlerFunc(revProxy.ServeReverseProxy)
 	router.PathPrefix(utils.PrivatePrefix + "/{version}/replication/symmetrix/{symid}").HandlerFunc(revProxy.ServeReverseProxy)
+	router.PathPrefix(utils.PrivatePrefix + "/{version}/sloprovisioning/symmetrix/{symid}").HandlerFunc(revProxy.ServeReverseProxy)
 	router.PathPrefix(utils.Prefix + "/{version}/replication/symmetrix/{symid}").HandlerFunc(revProxy.ServeReverseProxy)
 
 	// endpoints without symmetrix id

--- a/csireverseproxy/pkg/standaloneproxy/standaloneproxy.go
+++ b/csireverseproxy/pkg/standaloneproxy/standaloneproxy.go
@@ -106,7 +106,6 @@ func newReverseProxy(mgmtServer config.ManagementServer) common.Proxy {
 }
 
 func newTLSConfig(mgmtServer config.ManagementServer) *tls.Config {
-
 	tlsConfig := tls.Config{
 		InsecureSkipVerify: mgmtServer.SkipCertificateValidation, // #nosec G402 InsecureSkipVerify cannot be false always as expected by gosec, this needs to be configurable
 	}

--- a/service/controller.go
+++ b/service/controller.go
@@ -616,8 +616,8 @@ func (s *service) CreateVolume(
 	}
 	// Check existence of the Storage Group and create if necessary.
 	sg, err := pmaxClient.GetStorageGroup(ctx, symmetrixID, storageGroupName)
-	log.Debug(fmt.Sprintf("Unable to find storage group: %s", storageGroupName))
 	if err != nil || sg == nil {
+		log.Debug(fmt.Sprintf("Unable to find storage group: %s", storageGroupName))
 		hostLimitsParam := &types.SetHostIOLimitsParam{
 			HostIOLimitMBSec:    hostIOsec,
 			HostIOLimitIOSec:    hostMBsec,
@@ -705,6 +705,22 @@ func (s *service) CreateVolume(
 						err = s.LinkSRDFVolToVolume(ctx, reqID, symID, srcVol, vol, snapID, localProtectionGroupID, localRDFGrpNo, "false", false, pmaxClient)
 						if err != nil {
 							return nil, status.Errorf(codes.Internal, "Failed to create SRDF volume from volume (%s)", err.Error())
+						}
+					}
+				} else { // replication is not enabled
+					if srcSnapID != "" {
+						err = s.UnlinkTargets(ctx, symID, SrcDevID, pmaxClient)
+						if err != nil {
+							return nil, status.Errorf(codes.Internal, "Failed unlink existing target from snapshot (%s)", err.Error())
+						}
+						err = s.LinkVolumeToSnapshot(ctx, symID, srcVol.VolumeID, vol.VolumeID, snapID, reqID, false, pmaxClient)
+						if err != nil {
+							return nil, status.Errorf(codes.Internal, "Failed to create volume from snapshot (%s)", err.Error())
+						}
+					} else if srcVolID != "" {
+						err = s.LinkVolumeToVolume(ctx, symID, srcVol, vol.VolumeID, snapID, reqID, false, pmaxClient)
+						if err != nil {
+							return nil, status.Errorf(codes.Internal, "Failed to create volume from volume (%s)", err.Error())
 						}
 					}
 				}

--- a/service/controller.go
+++ b/service/controller.go
@@ -701,8 +701,8 @@ func (s *service) CreateVolume(
 						}
 					} else if srcVolID != "" {
 						// Build the temporary snapshot identifier
-						snapID := fmt.Sprintf("%s%s-%d", TempSnap, s.getClusterPrefix(), time.Now().Nanosecond())
-						err = s.LinkSRDFVolToVolume(ctx, reqID, symID, srcVol, vol, snapID, localProtectionGroupID, localRDFGrpNo, "false", false, pmaxClient)
+						tmpSnapID := fmt.Sprintf("%s%s-%d", TempSnap, s.getClusterPrefix(), time.Now().Nanosecond())
+						err = s.LinkSRDFVolToVolume(ctx, reqID, symID, srcVol, vol, tmpSnapID, localProtectionGroupID, localRDFGrpNo, "false", false, pmaxClient)
 						if err != nil {
 							return nil, status.Errorf(codes.Internal, "Failed to create SRDF volume from volume (%s)", err.Error())
 						}
@@ -718,7 +718,8 @@ func (s *service) CreateVolume(
 							return nil, status.Errorf(codes.Internal, "Failed to create volume from snapshot (%s)", err.Error())
 						}
 					} else if srcVolID != "" {
-						err = s.LinkVolumeToVolume(ctx, symID, srcVol, vol.VolumeID, snapID, reqID, false, pmaxClient)
+						tmpSnapID := fmt.Sprintf("%s%s-%d", TempSnap, s.getClusterPrefix(), time.Now().Nanosecond())
+						err = s.LinkVolumeToVolume(ctx, symID, srcVol, vol.VolumeID, tmpSnapID, reqID, false, pmaxClient)
 						if err != nil {
 							return nil, status.Errorf(codes.Internal, "Failed to create volume from volume (%s)", err.Error())
 						}

--- a/service/features/snapshot.feature
+++ b/service/features/snapshot.feature
@@ -649,7 +649,7 @@ Feature: PowerMax CSI Interface
             | induced               | numberOfSeconds | errormsg   |
             | "InduceOverloadError" | 5               | "overload" |
             | "InducePendingError"  | 5               | "pending"  |
-@v2.12
+@v2.12.0
     Scenario: Create a volume from another volume
         Given a PowerMax service
         And I call CreateVolume "volume1"
@@ -658,7 +658,7 @@ Feature: PowerMax CSI Interface
         Then a valid CreateVolumeResponse is returned
         When I call Create Volume from Volume
         Then a valid CreateVolumeResponse is returned
-@v2.12
+@v2.12.0
     Scenario: Create a volume from another volume and catch error message
         Given a PowerMax service
         And I call CreateVolume "volume1"
@@ -668,7 +668,7 @@ Feature: PowerMax CSI Interface
         And I induce error "MaxSnapSessionError"
         When I call Create Volume from Volume
         Then the error contains "Failed to create volume from volume"
-@v2.12
+@v2.12.0
     Scenario: Create a volume from another snapshot
         Given a PowerMax service
         And I call CreateVolume "volume1"
@@ -679,7 +679,7 @@ Feature: PowerMax CSI Interface
         Then a valid CreateVolumeResponse is returned
         When I call Create Volume from Snapshot
         Then a valid CreateVolumeResponse is returned
-@v2.12
+@v2.12.0
     Scenario: Create a volume from another snapshot and catch unlink target error
         Given a PowerMax service
         And I call CreateVolume "volume1"
@@ -691,7 +691,7 @@ Feature: PowerMax CSI Interface
         And I induce error "LinkSnapshotError"
         When I call Create Volume from Snapshot
         Then the error contains "Failed unlink existing target from snapshot"
-@v2.12
+@v2.12.0
     Scenario: Create a volume from another volume and catch linking error
         Given a PowerMax service
         And I call CreateVolume "volume1"

--- a/service/features/snapshot.feature
+++ b/service/features/snapshot.feature
@@ -649,3 +649,58 @@ Feature: PowerMax CSI Interface
             | induced               | numberOfSeconds | errormsg   |
             | "InduceOverloadError" | 5               | "overload" |
             | "InducePendingError"  | 5               | "pending"  |
+@v2.12
+    Scenario: Create a volume from another volume
+        Given a PowerMax service
+        And I call CreateVolume "volume1"
+        And a valid CreateVolumeResponse is returned
+        When I call Create Volume from Volume
+        Then a valid CreateVolumeResponse is returned
+        When I call Create Volume from Volume
+        Then a valid CreateVolumeResponse is returned
+@v2.12
+    Scenario: Create a volume from another volume and catch error message
+        Given a PowerMax service
+        And I call CreateVolume "volume1"
+        And a valid CreateVolumeResponse is returned
+        When I call Create Volume from Volume
+        Then a valid CreateVolumeResponse is returned
+        And I induce error "MaxSnapSessionError"
+        When I call Create Volume from Volume
+        Then the error contains "Failed to create volume from volume"
+@v2.12
+    Scenario: Create a volume from another snapshot
+        Given a PowerMax service
+        And I call CreateVolume "volume1"
+        And a valid CreateVolumeResponse is returned
+        And I call CreateSnapshot "snapshot1" on "volume1"
+        And a valid CreateSnapshotResponse is returned
+        When I call Create Volume from Snapshot
+        Then a valid CreateVolumeResponse is returned
+        When I call Create Volume from Snapshot
+        Then a valid CreateVolumeResponse is returned
+@v2.12
+    Scenario: Create a volume from another snapshot and catch unlink target error
+        Given a PowerMax service
+        And I call CreateVolume "volume1"
+        And a valid CreateVolumeResponse is returned
+        And I call CreateSnapshot "snapshot1" on "volume1"
+        And a valid CreateSnapshotResponse is returned
+        When I call Create Volume from Snapshot
+        Then a valid CreateVolumeResponse is returned
+        And I induce error "LinkSnapshotError"
+        When I call Create Volume from Snapshot
+        Then the error contains "Failed unlink existing target from snapshot"
+@v2.12
+    Scenario: Create a volume from another volume and catch linking error
+        Given a PowerMax service
+        And I call CreateVolume "volume1"
+        And a valid CreateVolumeResponse is returned
+        And I call CreateSnapshot "snapshot1" on "volume1"
+        And a valid CreateSnapshotResponse is returned
+        When I call Create Volume from Snapshot
+        Then a valid CreateVolumeResponse is returned
+        And I induce error "MaxSnapSessionError"
+        When I call Create Volume from Snapshot
+        Then the error contains "Failed to create volume from snapshot"
+        

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -51,7 +51,7 @@ func TestGoDog(t *testing.T) {
 	runOptions := godog.Options{
 		Format: "pretty",
 		Paths:  []string{"features"},
-		Tags:   "v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.6.0, v2.2.0, v2.3.0, v2.4.0, v2.5.0, v2.6.0, v2.7.0, v2.8.0, v2.9.0, v2.11.0",
+		Tags:   "v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.6.0, v2.2.0, v2.3.0, v2.4.0, v2.5.0, v2.6.0, v2.7.0, v2.8.0, v2.9.0, v2.11.0, v2.12",
 		// Tags:   "wip",
 		// Tags: "resiliency", // uncomment to run all node resiliency related tests,
 	}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -51,7 +51,7 @@ func TestGoDog(t *testing.T) {
 	runOptions := godog.Options{
 		Format: "pretty",
 		Paths:  []string{"features"},
-		Tags:   "v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.6.0, v2.2.0, v2.3.0, v2.4.0, v2.5.0, v2.6.0, v2.7.0, v2.8.0, v2.9.0, v2.11.0, v2.12",
+		Tags:   "v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.6.0, v2.2.0, v2.3.0, v2.4.0, v2.5.0, v2.6.0, v2.7.0, v2.8.0, v2.9.0, v2.11.0, v2.12.0",
 		// Tags:   "wip",
 		// Tags: "resiliency", // uncomment to run all node resiliency related tests,
 	}

--- a/service/snap.go
+++ b/service/snap.go
@@ -32,12 +32,13 @@ import (
 
 // The follow constants are for internal use within the pmax library.
 const (
-	TempSnap       = "CSI_TEMP_SNAP"
-	Defined        = "Defined"
-	Link           = "Link"
-	Unlink         = "Unlink"
-	Rename         = "Rename"
-	MaxUnlinkCount = 5
+	TempSnap        = "CSI_TEMP_SNAP"
+	Defined         = "Defined"
+	Link            = "Link"
+	Unlink          = "Unlink"
+	Rename          = "Rename"
+	MaxUnlinkCount  = 5
+	errDesiredState = "already in the desired state or mode"
 )
 
 var (
@@ -470,7 +471,11 @@ func (s *service) LinkVolumeToVolume(ctx context.Context, symID string, vol *typ
 	// Link the Target to the created snapshot
 	err = s.LinkVolumeToSnapshot(ctx, symID, vol.VolumeID, tgtDevID, snapID, reqID, isCopy, pmaxClient)
 	if err != nil {
-		return err
+		if strings.Contains(err.Error(), errDesiredState) {
+			log.Infof("Link of %s on %s is in desired state", vol.VolumeID, tgtDevID)
+		} else {
+			return err
+		}
 	}
 	// Push the temporary snapshot created for cleanup
 	var cleanReq snapCleanupRequest

--- a/test/integration/features/integration.feature
+++ b/test/integration/features/integration.feature
@@ -994,7 +994,7 @@ Feature: Powermax OS CSI interface
     And I call Delete RemoteStorageProtectionGroup
     And there are no errors
 
-  @2.12
+  @2.12.0
   Scenario: Creating a Volume from newly created Volume from Volume
     Given a Powermax service
     And a basic block volume request "integration1" "50"
@@ -1007,7 +1007,7 @@ Feature: Powermax OS CSI interface
     And when I call DeleteAllVolumes
     And there are no errors
 
-  @2.12
+  @2.12.0
   Scenario: Creating a Volume from newly created Spanshot
     Given a Powermax service
     And a basic block volume request "integration1" "50"

--- a/test/integration/features/integration.feature
+++ b/test/integration/features/integration.feature
@@ -993,3 +993,31 @@ Feature: Powermax OS CSI interface
     And there are no errors
     And I call Delete RemoteStorageProtectionGroup
     And there are no errors
+
+  @2.12
+  Scenario: Creating a Volume from newly created Volume from Volume
+    Given a Powermax service
+    And a basic block volume request "integration1" "50"
+    When I call CreateVolume
+    And there are no errors
+    Then I call LinkVolumeToVolume
+    And there are no errors
+    Then I call LinkVolumeToVolumeAgain
+    And there are no errors
+    And when I call DeleteAllVolumes
+    And there are no errors
+
+  @2.12
+  Scenario: Creating a Volume from newly created Spanshot
+    Given a Powermax service
+    And a basic block volume request "integration1" "50"
+    When I call CreateVolume
+    And there are no errors
+    And I call CreateSnapshot
+    And there are no errors
+    Then I call LinkVolumeToSnapshot
+    And there are no errors
+    Then I call LinkVolumeToSnapshotAgain
+    And there are no errors
+    And when I call DeleteAllVolumes
+    And there are no errors  

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -96,7 +96,7 @@ func TestMain(m *testing.M) {
 		Output: write,
 		Format: "junit",
 		Paths:  []string{"features"},
-		Tags:   "@v1.0.0,@v1.1.0,@v1.2.0,@v1.4.0,@v1.6.0,@v2.2.0,@v2.4.0,@v2.7.0",
+		Tags:   "@v1.0.0,@v1.1.0,@v1.2.0,@v1.4.0,@v1.6.0,@v2.2.0,@v2.4.0,@v2.7.0,@2.12.0",
 	}
 	godogExit := godog.TestSuite{
 		Name:                "CSI Powermax Int Tests",

--- a/test/integration/step_defs_test.go
+++ b/test/integration/step_defs_test.go
@@ -1093,9 +1093,33 @@ func (f *feature) iCallLinkVolumeToSnapshot() error {
 	return nil
 }
 
+func (f *feature) iCallLinkVolumeToSnapshotAgain() error {
+	req := f.createVolumeRequest
+	source := &csi.VolumeContentSource_SnapshotSource{SnapshotId: f.snapshotID}
+	req.VolumeContentSource = new(csi.VolumeContentSource)
+	req.VolumeContentSource.Type = &csi.VolumeContentSource_Snapshot{Snapshot: source}
+	fmt.Printf("Calling CreateVolume with snapshot source")
+
+	_ = f.createAVolume(req, "single CreateVolume from Snap")
+	time.Sleep(SleepTime)
+	return nil
+}
+
 func (f *feature) iCallLinkVolumeToVolume() error {
 	req := f.createVolumeRequest
 	req.Name = "volFromVol-" + req.Name
+	source := &csi.VolumeContentSource_VolumeSource{VolumeId: f.volID}
+	req.VolumeContentSource = new(csi.VolumeContentSource)
+	req.VolumeContentSource.Type = &csi.VolumeContentSource_Volume{Volume: source}
+	fmt.Printf("Calling CreateVolume with volume source")
+
+	_ = f.createAVolume(req, "single CreateVolume from Volume")
+	time.Sleep(SleepTime)
+	return nil
+}
+
+func (f *feature) iCallLinkVolumeToVolumeAgain() error {
+	req := f.createVolumeRequest
 	source := &csi.VolumeContentSource_VolumeSource{VolumeId: f.volID}
 	req.VolumeContentSource = new(csi.VolumeContentSource)
 	req.VolumeContentSource.Type = &csi.VolumeContentSource_Volume{Volume: source}
@@ -2213,6 +2237,7 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^when I call DeleteAllVolumes$`, f.whenICallDeleteAllVolumes)
 	s.Step(`^I call DeleteSnapshot$`, f.iCallDeleteSnapshot)
 	s.Step(`^I call LinkVolumeToSnapshot$`, f.iCallLinkVolumeToSnapshot)
+	s.Step(`^I call LinkVolumeToSnapshotAgain$`, f.iCallLinkVolumeToSnapshotAgain)
 	s.Step(`^I call CreateManyVolumesFromSnapshot$`, f.iCallCreateManyVolumesFromSnapshot)
 	s.Step(`^I call ListVolume$`, f.iCallListVolume)
 	s.Step(`^a valid ListVolumeResponse is returned$`, f.aValidListVolumeResponseIsReturned)
@@ -2242,6 +2267,7 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^I node unstage (\d+) volumes in parallel$`, f.iNodeUnstageVolumesInParallel)
 	s.Step(`^the volume size is "([^"]*)"$`, f.theVolumeSizeIs)
 	s.Step(`^I call LinkVolumeToVolume$`, f.iCallLinkVolumeToVolume)
+	s.Step(`^I call LinkVolumeToVolumeAgain$`, f.iCallLinkVolumeToVolumeAgain)
 	s.Step(`^I create (\d+) snapshots in parallel$`, f.iCreateSnapshotsInParallel)
 	s.Step(`^I create (\d+) volumes from snapshot in parallel$`, f.iCreateVolumesFromSnapshotInParallel)
 	s.Step(`^I create (\d+) volumes from volume in parallel$`, f.iCreateVolumesFromVolumeInParallel)


### PR DESCRIPTION
# Description
Issue: When a bootable source volume is cloned, the cloned (target) volume is seen to be empty, so the resulting VM cannot boot.

Cause: The array's delayed response to the REST API request causes the initial clone workflow to fail. The retry process does not adequately check if the target volume has been properly created and linked to the snapshot. This leads to an empty volume being created

Solution: We improved the driver's ability to handle Powermax array busy states. This was achieved by adding additional idempotency checks to ensure the target volume was created and linked to the temporary snapshot before mounting the target volume to the VM.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1425 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Unit test results:

**standaloneproxy results:**
```
RESPONSE_BODY: 
time="2024-08-28T11:14:00Z" level=info msg="Request ID: 8 - GET /univmax/restapi/private/91/sloprovisioning/symmetrix/000000000001"
RESPONSE_BODY: 
PASS
ok      revproxy/v2     0.253s
```

unit-test:
```
--- PASS: TestLocks (0.16s)
=== RUN   TestGetVolSize
=== RUN   TestGetVolSize/#00
=== PAUSE TestGetVolSize/#00
=== RUN   TestGetVolSize/#01
=== PAUSE TestGetVolSize/#01
=== RUN   TestGetVolSize/#02
=== PAUSE TestGetVolSize/#02
=== RUN   TestGetVolSize/#03
=== PAUSE TestGetVolSize/#03
=== RUN   TestGetVolSize/#04
=== PAUSE TestGetVolSize/#04
=== RUN   TestGetVolSize/#05
=== PAUSE TestGetVolSize/#05
=== RUN   TestGetVolSize/#06
=== PAUSE TestGetVolSize/#06
=== RUN   TestGetVolSize/#07
=== PAUSE TestGetVolSize/#07
=== RUN   TestGetVolSize/#08
=== PAUSE TestGetVolSize/#08
=== RUN   TestGetVolSize/#09
=== PAUSE TestGetVolSize/#09
=== RUN   TestGetVolSize/#10
=== PAUSE TestGetVolSize/#10
=== CONT  TestGetVolSize/#00
=== CONT  TestGetVolSize/#06
=== CONT  TestGetVolSize/#05
=== CONT  TestGetVolSize/#04
=== CONT  TestGetVolSize/#10
=== CONT  TestGetVolSize/#03
=== CONT  TestGetVolSize/#02
=== CONT  TestGetVolSize/#01
=== CONT  TestGetVolSize/#08
=== CONT  TestGetVolSize/#07
=== CONT  TestGetVolSize/#09
--- PASS: TestGetVolSize (0.00s)
    --- PASS: TestGetVolSize/#00 (0.00s)
    --- PASS: TestGetVolSize/#05 (0.00s)
    --- PASS: TestGetVolSize/#06 (0.00s)
    --- PASS: TestGetVolSize/#04 (0.00s)
    --- PASS: TestGetVolSize/#10 (0.00s)
    --- PASS: TestGetVolSize/#02 (0.00s)
    --- PASS: TestGetVolSize/#01 (0.00s)
    --- PASS: TestGetVolSize/#03 (0.00s)
    --- PASS: TestGetVolSize/#08 (0.00s)
    --- PASS: TestGetVolSize/#07 (0.00s)
    --- PASS: TestGetVolSize/#09 (0.00s)
=== RUN   TestVolumeIdentifier
--- PASS: TestVolumeIdentifier (0.00s)
=== RUN   TestMetroCSIDeviceID
--- PASS: TestMetroCSIDeviceID (0.00s)
=== RUN   TestStringSliceComparison
--- PASS: TestStringSliceComparison (0.00s)
=== RUN   TestStringSliceRegexMatcher
--- PASS: TestStringSliceRegexMatcher (0.00s)
=== RUN   TestExecCommandHelper
--- PASS: TestExecCommandHelper (0.00s)
=== RUN   TestAppendIfMissing
--- PASS: TestAppendIfMissing (0.00s)
=== RUN   TestTruncateString
--- PASS: TestTruncateString (0.00s)
=== RUN   TestFibreChannelSplitInitiatorID
--- PASS: TestFibreChannelSplitInitiatorID (0.00s)
=== RUN   TestPending
--- PASS: TestPending (0.00s)
=== RUN   TestGobrickInitialization
--- PASS: TestGobrickInitialization (0.00s)
=== RUN   TestSetGetLogFields
--- PASS: TestSetGetLogFields (0.00s)
=== RUN   TestEsnureISCSIDaemonIsStarted
--- PASS: TestEsnureISCSIDaemonIsStarted (0.00s)
PASS
status 0
ok      github.com/dell/csi-powermax/v2/service 210.290s        coverage: 75.7% of statements
```

**godog result:**
```
681 scenarios (681 passed)
4578 steps (4578 passed)
3m29.953490046s
godog finished
--- PASS: TestGoDog (210.03s)
PASS
coverage: 74.5% of statements
status 0
ok      github.com/dell/csi-powermax/v2/service 210.447s        coverage: 74.5% of statements
```

Int test results:
ok      command-line-arguments  86.931s coverage: 11.0% of statements in ../../service