### PR TITLE
Added make target to build without cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ docker:
 	sh ./build.sh -i ubimicro -e -o
 
 # Generates the docker container without cache (but does not push)
-docker:
+docker-no-cache:
 	go generate
 	go run core/semver/semver.go -f mk >semver.mk
 	sh ./build.sh -i ubimicro -e -o -n

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,12 @@ docker:
 	go run core/semver/semver.go -f mk >semver.mk
 	sh ./build.sh -i ubimicro -e -o
 
+# Generates the docker container without cache (but does not push)
+docker:
+	go generate
+	go run core/semver/semver.go -f mk >semver.mk
+	sh ./build.sh -i ubimicro -e -o -n
+
 # Pushes container to the repository
 push:	docker
 	make -f docker.mk push

--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,7 @@ PUSH_IMAGE=false
 BUILD_REVPROXY=false
 OVERWRITE_IMAGE=false
 EXTRA_TAGS=false
+NOCACHE=
 
 function print_usage {
    echo
@@ -156,7 +157,7 @@ function build_image {
       exit 1
    fi
    if [ "$EXTRA_TAGS" = true ]; then
-      echo $BUILDCMD build -t $IMAGE_VERSION_TAG\
+      echo $BUILDCMD build $NOCACHE -t $IMAGE_VERSION_TAG\
                 -t $IMAGE_LATEST_TAG\
                 -t $IMAGE_VERSION_WITH_PATCH_TAG\
                 -f csi-powermax/Dockerfile.build .\
@@ -168,7 +169,7 @@ function build_image {
                 --build-arg IMAGE_TYPE=$IMAGE_TYPE\
                 $DOCKEROPT
       (cd .. &&
-       $BUILDCMD build -t "$IMAGE_VERSION_TAG"\
+       $BUILDCMD build $NOCACHE -t "$IMAGE_VERSION_TAG"\
                 -t "$IMAGE_LATEST_TAG"\
                 -t "$IMAGE_VERSION_WITH_PATCH_TAG"\
                 -f csi-powermax/Dockerfile.build .\
@@ -184,7 +185,7 @@ function build_image {
          (cd csireverseproxy && $BUILDCMD build -t "$REVPROXY_IMAGE_VERSION_TAG" --build-arg GOIMAGE="$DEFAULT_GOIMAGE" . )
        fi
    else
-      echo $BUILDCMD build -t $IMAGE_VERSION_TAG\
+      echo $BUILDCMD build $NOCACHE -t $IMAGE_VERSION_TAG\
                 -f csi-powermax/Dockerfile.build .\
                 --build-arg BUILD_NUMBER=$BUILD_NUMBER\
                 --build-arg BUILD_TYPE=$BUILD_TYPE\
@@ -194,7 +195,7 @@ function build_image {
                 --build-arg IMAGE_TYPE="$IMAGE_TYPE"\
                 $DOCKEROPT
       (cd .. &&
-       $BUILDCMD build -t "$IMAGE_VERSION_TAG"\
+       $BUILDCMD build $NOCACHE -t "$IMAGE_VERSION_TAG"\
                 -f csi-powermax/Dockerfile.build .\
                 --build-arg BUILD_NUMBER="$BUILD_NUMBER"\
                 --build-arg BUILD_TYPE="$BUILD_TYPE"\
@@ -254,6 +255,7 @@ while getopts 'cpyheori:' flag; do
   case "${flag}" in
     c) DELETE_IMAGE='true' ;;
     p) PUSH_IMAGE='true' ;;
+    n) NOCACHE='--no-cache' ;;
     y) NOPROMPT='true' ;;
     e) EXTRA_TAGS='true' ;;
     o) OVERWRITE_IMAGE='true' ;;

--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,7 @@ function print_usage {
    echo "    -i      - Set the image type. Accepted values are ubim, ubimicro, ubi, centos and rhel"
    echo "    -r      - Build the CSI PowerMax ReverseProxy image along with driver image"
    echo "    -c      - Delete the local image after a successful build"
+   echo "    -n      - Build csi-powermax image with no cache option"
    echo
    echo "Default values are specified via the .build.config file. They can be overridden by creating a .build.config.user file"
 }
@@ -251,7 +252,7 @@ function set_image_type {
 }
 IMAGE_TYPE_SET=false
 # Read options
-while getopts 'cpyheori:' flag; do
+while getopts 'cpnyheori:' flag; do
   case "${flag}" in
     c) DELETE_IMAGE='true' ;;
     p) PUSH_IMAGE='true' ;;

--- a/service/node.go
+++ b/service/node.go
@@ -2542,6 +2542,7 @@ func (s *service) retryableCreateHost(ctx context.Context, array string, nodeNam
 				}
 			}
 			log.Debug(fmt.Sprintf("failed to create Host; retrying..."))
+			// #nosec G115
 			time.Sleep(time.Second << uint(tries)) // incremental back-off
 			continue
 		}
@@ -2563,6 +2564,7 @@ func (s *service) retryableUpdateHostInitiators(ctx context.Context, array strin
 		if err != nil {
 			// Retry on this error
 			log.Debug(fmt.Sprintf("failed to update Host; retrying..."))
+			// #nosec G115
 			time.Sleep(time.Second << uint(tries)) // incremental back-off
 			continue
 		}


### PR DESCRIPTION
# Description
Image build job fails because of no space left on the build machine. This is caused by overlay images created during the build process

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1448 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- [x] Tested build and there are no overlay containers left mounted on the build machine























