### PR TITLE
Add snapshot RestoreSize

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To build the source, execute `make clean build`.
 
 To run unit tests, execute `make unit-test`.
 
-To build an image, execute `make docker`.
+To build an image, copy all dependent repos (see Dockerfile.sh) into the same folder with csi-powermax, then `cd` into `csi-powermax` and execute `make docker`.
 
 You can run an integration test on a Linux system by populating the file `env.sh` with values for your Dell PowerMax systems and then run "`make integration-test`".
 

--- a/service/controller.go
+++ b/service/controller.go
@@ -3311,10 +3311,6 @@ func (s *service) CreateSnapshot(
 
 	snapID = fmt.Sprintf("%s-%s-%s", snap.SnapshotName, symID, devID)
 	// populate response structure
-	// log.Debugf("vol.FloatCapacityMB = %f, int64(vol.FloatCapacityMB) = %d, MiBSizeInBytes = %d, int64(vol.FloatCapacityMB) * MiBSizeInBytes = %d", 
-	//	   vol.FloatCapacityMB, int64(vol.FloatCapacityMB), MiBSizeInBytes, int64(vol.FloatCapacityMB) * MiBSizeInBytes)
-	log.Debugf("cylinderSizeInBytes = %d, vol.CapacityCYL = %d, int64(cylinderSizeInBytes * vol.CapacityCYL) = %d", 
-		   cylinderSizeInBytes, vol.CapacityCYL, int64(cylinderSizeInBytes * vol.CapacityCYL))
 	snapshot := &csi.Snapshot{
 		SizeBytes:      int64(cylinderSizeInBytes * vol.CapacityCYL),
 		SnapshotId:     snapID,

--- a/service/controller.go
+++ b/service/controller.go
@@ -3312,7 +3312,7 @@ func (s *service) CreateSnapshot(
 	snapID = fmt.Sprintf("%s-%s-%s", snap.SnapshotName, symID, devID)
 	// populate response structure
 	snapshot := &csi.Snapshot{
-		SizeBytes:      int64(vol.SizeInKb) * bytesInKiB,
+		SizeBytes:      int64(vol.FloatCapacityMB) * MiBSizeInBytes,
 		SnapshotId:     snapID,
 		SourceVolumeId: volID,
 		ReadyToUse:     true,

--- a/service/controller.go
+++ b/service/controller.go
@@ -3312,6 +3312,7 @@ func (s *service) CreateSnapshot(
 	snapID = fmt.Sprintf("%s-%s-%s", snap.SnapshotName, symID, devID)
 	// populate response structure
 	snapshot := &csi.Snapshot{
+		SizeBytes:      int64(vol.SizeInKb) * bytesInKiB,
 		SnapshotId:     snapID,
 		SourceVolumeId: volID,
 		ReadyToUse:     true,

--- a/service/controller.go
+++ b/service/controller.go
@@ -3311,8 +3311,8 @@ func (s *service) CreateSnapshot(
 
 	snapID = fmt.Sprintf("%s-%s-%s", snap.SnapshotName, symID, devID)
 	// populate response structure
-	log.Debugf("vol.FloatCapacityMB = %f, int64(vol.FloatCapacityMB) = %d, MiBSizeInBytes = %d, int64(vol.FloatCapacityMB) * MiBSizeInBytes = %d, SizeBytes = %d", 
-		   vol.FloatCapacityMB, int64(vol.FloatCapacityMB), MiBSizeInBytes, int64(vol.FloatCapacityMB) * MiBSizeInBytes, snapshot.SizeBytes)
+	log.Debugf("vol.FloatCapacityMB = %f, int64(vol.FloatCapacityMB) = %d, MiBSizeInBytes = %d, int64(vol.FloatCapacityMB) * MiBSizeInBytes = %d", 
+		   vol.FloatCapacityMB, int64(vol.FloatCapacityMB), MiBSizeInBytes, int64(vol.FloatCapacityMB) * MiBSizeInBytes)
 	snapshot := &csi.Snapshot{
 		SizeBytes:      int64(vol.FloatCapacityMB) * MiBSizeInBytes,
 		SnapshotId:     snapID,

--- a/service/controller.go
+++ b/service/controller.go
@@ -3320,7 +3320,7 @@ func (s *service) CreateSnapshot(
 	}
 	resp := &csi.CreateSnapshotResponse{Snapshot: snapshot}
 
-	log.Debugf("Created snapshot: SnapshotId %s SourceVolumeId %s CreationTime %s SizeBytes %s",
+	log.Debugf("Created snapshot: SnapshotId %s SourceVolumeId %s CreationTime %s SizeBytes %d",
 		snapshot.SnapshotId, snapshot.SourceVolumeId, snapshot.CreationTime.AsTime().Format(time.RFC3339Nano), snapshot.SizeBytes)
 	return resp, nil
 }

--- a/service/controller.go
+++ b/service/controller.go
@@ -3311,6 +3311,8 @@ func (s *service) CreateSnapshot(
 
 	snapID = fmt.Sprintf("%s-%s-%s", snap.SnapshotName, symID, devID)
 	// populate response structure
+	log.Debugf("vol.FloatCapacityMB = %f, int64(vol.FloatCapacityMB) = %d, MiBSizeInBytes = %d, int64(vol.FloatCapacityMB) * MiBSizeInBytes = %d, SizeBytes = %d", 
+		   vol.FloatCapacityMB, int64(vol.FloatCapacityMB), MiBSizeInBytes, int64(vol.FloatCapacityMB) * MiBSizeInBytes, snapshot.SizeBytes)
 	snapshot := &csi.Snapshot{
 		SizeBytes:      int64(vol.FloatCapacityMB) * MiBSizeInBytes,
 		SnapshotId:     snapID,

--- a/service/controller.go
+++ b/service/controller.go
@@ -3320,7 +3320,7 @@ func (s *service) CreateSnapshot(
 	}
 	resp := &csi.CreateSnapshotResponse{Snapshot: snapshot}
 
-	log.Debugf("Created snapshot: SnapshotId %s SourceVolumeId %s CreationTime %s" SizeBytes %s,
+	log.Debugf("Created snapshot: SnapshotId %s SourceVolumeId %s CreationTime %s SizeBytes %s",
 		snapshot.SnapshotId, snapshot.SourceVolumeId, snapshot.CreationTime.AsTime().Format(time.RFC3339Nano), snapshot.SizeBytes)
 	return resp, nil
 }

--- a/service/controller.go
+++ b/service/controller.go
@@ -3320,8 +3320,8 @@ func (s *service) CreateSnapshot(
 	}
 	resp := &csi.CreateSnapshotResponse{Snapshot: snapshot}
 
-	log.Debugf("Created snapshot: SnapshotId %s SourceVolumeId %s CreationTime %s",
-		snapshot.SnapshotId, snapshot.SourceVolumeId, snapshot.CreationTime.AsTime().Format(time.RFC3339Nano))
+	log.Debugf("Created snapshot: SnapshotId %s SourceVolumeId %s CreationTime %s" SizeBytes %s,
+		snapshot.SnapshotId, snapshot.SourceVolumeId, snapshot.CreationTime.AsTime().Format(time.RFC3339Nano), snapshot.SizeBytes)
 	return resp, nil
 }
 

--- a/service/controller.go
+++ b/service/controller.go
@@ -3311,10 +3311,12 @@ func (s *service) CreateSnapshot(
 
 	snapID = fmt.Sprintf("%s-%s-%s", snap.SnapshotName, symID, devID)
 	// populate response structure
-	log.Debugf("vol.FloatCapacityMB = %f, int64(vol.FloatCapacityMB) = %d, MiBSizeInBytes = %d, int64(vol.FloatCapacityMB) * MiBSizeInBytes = %d", 
-		   vol.FloatCapacityMB, int64(vol.FloatCapacityMB), MiBSizeInBytes, int64(vol.FloatCapacityMB) * MiBSizeInBytes)
+	// log.Debugf("vol.FloatCapacityMB = %f, int64(vol.FloatCapacityMB) = %d, MiBSizeInBytes = %d, int64(vol.FloatCapacityMB) * MiBSizeInBytes = %d", 
+	//	   vol.FloatCapacityMB, int64(vol.FloatCapacityMB), MiBSizeInBytes, int64(vol.FloatCapacityMB) * MiBSizeInBytes)
+	log.Debugf("cylinderSizeInBytes = %d, vol.CapacityCYL = %d, int64(cylinderSizeInBytes * vol.CapacityCYL) = %d", 
+		   cylinderSizeInBytes, vol.CapacityCYL, int64(cylinderSizeInBytes * vol.CapacityCYL))
 	snapshot := &csi.Snapshot{
-		SizeBytes:      int64(vol.FloatCapacityMB) * MiBSizeInBytes,
+		SizeBytes:      int64(cylinderSizeInBytes * vol.CapacityCYL),
 		SnapshotId:     snapID,
 		SourceVolumeId: volID,
 		ReadyToUse:     true,

--- a/test/helm/1clonevol/templates/pvc0.yaml
+++ b/test/helm/1clonevol/templates/pvc0.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: restorepvc
-  namespace: test
+  namespace: namespace: {{ .Values.namespace }}
 spec:
   storageClassName: {{ .Values.sc }}
   dataSource:

--- a/test/helm/2vols+restore/templates/createFromSnap.yaml
+++ b/test/helm/2vols+restore/templates/createFromSnap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: restorepvc
-  namespace: test
+  namespace: {{ .Values.namespace }}
 spec:
   storageClassName: {{ .Values.sc }}
   dataSource:
@@ -13,4 +13,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 8Gi
+      storage: 8194Mi

--- a/test/helm/2vols+restore/templates/pvc0.yaml
+++ b/test/helm/2vols+restore/templates/pvc0.yaml
@@ -2,7 +2,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvol0
-  namespace: test
+  namespace: {{ .Values.namespace }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/test/helm/2vols+restore/templates/pvc1.yaml
+++ b/test/helm/2vols+restore/templates/pvc1.yaml
@@ -2,7 +2,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvol1
-  namespace: test
+  namespace: {{ .Values.namespace }}
 spec:
   accessModes:
   - ReadWriteOnce

--- a/test/helm/2vols+restore/templates/test.yaml
+++ b/test/helm/2vols+restore/templates/test.yaml
@@ -2,13 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     name: powermaxtest
-    namespace: test
+    namespace: {{ .Values.namespace }}
 ---
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
     name: powermaxtest
-    namespace: test
+    namespace: {{ .Values.namespace }}
 spec:
     selector:
         matchLabels:

--- a/test/helm/snaprestoretest.sh
+++ b/test/helm/snaprestoretest.sh
@@ -85,7 +85,7 @@ sleep 10
 kubectl get volumesnapshot -n $NAMESPACE
 echo "updating container to add a volume sourced from snapshot"
 helm upgrade -n $NAMESPACE 2vols 2vols+restore --set sc=$STORAGE_CLASS --set scxfs=$STORAGE_CLASS_XFS
-echo "waiting for container to upgrade/stabalize"
+echo "waiting for container to upgrade/stabilize"
 sleep 20
 up=0
 while [ $up -lt 1 ];
@@ -95,8 +95,8 @@ do
     up=`kubectl get pods -n $NAMESPACE | grep '1/1 *Running' | wc -l`
 done
 kubectl describe pods -n $NAMESPACE
-kubectl exec -n $NAMESPACE powermaxtest-0 -it df | grep data
-kubectl exec -n $NAMESPACE powermaxtest-0 -it mount | grep data
+kubectl exec -n $NAMESPACE powermaxtest-0 -- df | grep data
+kubectl exec -n $NAMESPACE powermaxtest-0 -- mount | grep data
 echo "updating container finished"
 echo "marking volume"
 kubectl exec -n $NAMESPACE powermaxtest-0 -- touch /data2/new

--- a/test/helm/starttest.sh
+++ b/test/helm/starttest.sh
@@ -125,5 +125,5 @@ sleep 60
 kubectl describe pods -n "${NAMESPACE}"
 waitOnRunning 1
 kubectl describe pods -n "${NAMESPACE}"
-kubectl exec -n "${NAMESPACE}" powermaxtest-0 -it df | grep data
-kubectl exec -n "${NAMESPACE}" powermaxtest-0 -it mount | grep data
+kubectl exec -n "${NAMESPACE}" powermaxtest-0 -- df | grep data
+kubectl exec -n "${NAMESPACE}" powermaxtest-0 -- mount | grep data


### PR DESCRIPTION
# Description
Currently, when the csi-powermax takes a snapshot of a volume, it does not set a RestoreSize for the snapshot. This PR adds the sizeInBytes field to the snapshot to set the RestoreSize. The following additional work is also done:
1) Add clarification to README about building the PMax image.
2) Fix several places in the helm tests where a namespace was hardcoded.
3) Update some deprecated `kubectl exec` commands in helm tests.
4) Update the size of the pvc being restored to in the `2vols+restore` helm test to 8194Mi -- even though the requested size of the original volume was 8Gi (8192Mi), PMax rounds to the next cylinder boundary, which gives the pvc an actual size of 8194Mi. A separate doc PR will go up in relation to this.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Ran unit tests, snaprestore helm test, and a full cert-csi suite.