### PR TITLE
Clarify which secret is for which unisphere in reverseproxy configmap

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v4
       - name: Run the formatter, linter, and vetter
-        uses: dell/common-github-actions/go-code-formatter-linter-vetter@main
+        uses: dell/common-github-actions/go-code-formatter-vetter@main
         with:
           directories: ./...
   test:

--- a/csireverseproxy/deploy/config.yaml
+++ b/csireverseproxy/deploy/config.yaml
@@ -8,14 +8,14 @@ standAloneConfig:
       primaryURL: https://primary-1.unisphe.re:8443
       backupURL: https://backup-1.unisphe.re:8443
       proxyCredentialSecrets:
-        - proxy-secret-11
-        - proxy-secret-12
+        - primary-1-secret
+        - backup-1-secret
     - storageArrayId: "000000000002"
       primaryURL: https://primary-2.unisphe.re:8443
       backupURL: https://backup-2.unisphe.re:8443
       proxyCredentialSecrets:
-        - proxy-secret-21
-        - proxy-secret-22
+        - primary-2-secret
+        - backup-2-secret
   managementServers:
     - url: https://primary-1.unisphe.re:8443
       arrayCredentialSecret: primary-1-secret

--- a/csireverseproxy/deploy/config.yaml
+++ b/csireverseproxy/deploy/config.yaml
@@ -8,24 +8,24 @@ standAloneConfig:
       primaryURL: https://primary-1.unisphe.re:8443
       backupURL: https://backup-1.unisphe.re:8443
       proxyCredentialSecrets:
-        - primary-1-secret
-        - backup-1-secret
+        - primary-unisphere-secret-1
+        - backup-unisphere-secret-1
     - storageArrayId: "000000000002"
       primaryURL: https://primary-2.unisphe.re:8443
       backupURL: https://backup-2.unisphe.re:8443
       proxyCredentialSecrets:
-        - primary-2-secret
-        - backup-2-secret
+        - primary-unisphere-secret-2
+        - backup-unisphere-secret-2
   managementServers:
     - url: https://primary-1.unisphe.re:8443
-      arrayCredentialSecret: primary-1-secret
+      arrayCredentialSecret: primary-unisphere-secret-1
       skipCertificateValidation: true
     - url: https://backup-1.unisphe.re:8443
-      arrayCredentialSecret: backup-1-secret
+      arrayCredentialSecret: backup-unisphere-secret-1
       skipCertificateValidation: false
     - url: https://primary-2.unisphe.re:8443
-      arrayCredentialSecret: primary-2-secret
+      arrayCredentialSecret: primary-unisphere-secret-2
       skipCertificateValidation: true
     - url: https://backup-2.unisphe.re:8443
-      arrayCredentialSecret: backup-2-secret
+      arrayCredentialSecret: backup-unisphere-secret-2
       skipCertificateValidation: false

--- a/csireverseproxy/test-config/config.yaml
+++ b/csireverseproxy/test-config/config.yaml
@@ -6,14 +6,14 @@ standAloneConfig:
       primaryURL: https://primary-1.unisphe.re:8443
       backupURL: https://backup-1.unisphe.re:8443
       proxyCredentialSecrets:
-        - proxy-secret-11
-        - proxy-secret-12
+        - primary-1-secret
+        - backup-1-secret
     - storageArrayId: "000000000002"
       primaryURL: https://primary-2.unisphe.re:8443
       backupURL: https://backup-2.unisphe.re:8443
       proxyCredentialSecrets:
-        - proxy-secret-21
-        - proxy-secret-22
+        - primary-2-secret
+        - backup-2-secret
   managementServers:
     - url: https://primary-1.unisphe.re:8443
       arrayCredentialSecret: primary-1-secret

--- a/csireverseproxy/test-config/config.yaml
+++ b/csireverseproxy/test-config/config.yaml
@@ -6,24 +6,24 @@ standAloneConfig:
       primaryURL: https://primary-1.unisphe.re:8443
       backupURL: https://backup-1.unisphe.re:8443
       proxyCredentialSecrets:
-        - primary-1-secret
-        - backup-1-secret
+        - primary-unisphere-secret-1
+        - backup-unisphere-secret-1
     - storageArrayId: "000000000002"
       primaryURL: https://primary-2.unisphe.re:8443
       backupURL: https://backup-2.unisphe.re:8443
       proxyCredentialSecrets:
-        - primary-2-secret
-        - backup-2-secret
+        - primary-unisphere-secret-2
+        - backup-unisphere-secret-2
   managementServers:
     - url: https://primary-1.unisphe.re:8443
-      arrayCredentialSecret: primary-1-secret
+      arrayCredentialSecret: primary-unisphere-secret-1
       skipCertificateValidation: true
     - url: https://backup-1.unisphe.re:8443
-      arrayCredentialSecret: backup-1-secret
+      arrayCredentialSecret: backup-unisphere-secret-1
       skipCertificateValidation: false
     - url: https://primary-2.unisphe.re:8443
-      arrayCredentialSecret: primary-2-secret
+      arrayCredentialSecret: primary-unisphere-secret-2
       skipCertificateValidation: true
     - url: https://backup-2.unisphe.re:8443
-      arrayCredentialSecret: backup-2-secret
+      arrayCredentialSecret: backup-unisphere-secret-2
       skipCertificateValidation: false

--- a/pkg/symmetrix/powermax.go
+++ b/pkg/symmetrix/powermax.go
@@ -73,8 +73,8 @@ type ReplicationCapabilitiesCache struct {
 	time CacheTime
 }
 
-func (rep *ReplicationCapabilitiesCache) update(cap *types.SymmetrixCapability) {
-	rep.cap = cap
+func (rep *ReplicationCapabilitiesCache) update(capability *types.SymmetrixCapability) {
+	rep.cap = capability
 	rep.time.Set(SnapLicenseCacheValidity)
 }
 

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -66,7 +66,7 @@ func TestGet(t *testing.T) {
 	header := metadata.New(map[string]string{"csi.requestid": "1"})
 	ctx := metadata.NewIncomingContext(context.Background(), header)
 
-        _, err = Get(ctx, c, "0001")
+        _, err = ReplicationCapabilitiesCache.Get(ctx, c, "0001")
         if err != nil {
                 t.Errorf("Faied to create client with only primary managed array specified")
         }

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -64,7 +64,7 @@ func TestUpdate(t *testing.T) {
 	}
 	rep := ReplicationCapabilitiesCache{}
         rep.update(symmetrixCapability)
-        if rep.cap != symmetrixCapability {
+        if rep.cap.SymmetrixID == "fakeSymmetrix" and rep.cap.SnapVxCapable and rep.cap.RdfCapable {
                 t.Errorf("update call failed -- capability not set")
         }
 }

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	pmax "github.com/dell/gopowermax/v2"
+	types "github.com/dell/gopowermax/v2/types/v100"
+
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/metadata"
 )
@@ -58,7 +60,7 @@ func TestGetPowerMaxClient(t *testing.T) {
 
 // ctx context.Context, client pmax.Pmax, symID string
 func TestUpdate(t *testing.T) {
-	symmetrixCapability = SymmetrixCapability{
+	symmetrixCapability = types.SymmetrixCapability{
 		SymmetrixID: "fakeSymmetrix",
 		SnapVxCapable: true,
 		RdfCapable: true,

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -58,17 +58,19 @@ func TestGetPowerMaxClient(t *testing.T) {
 
 // ctx context.Context, client pmax.Pmax, symID string
 func TestGet(t *testing.T) {
-        c, err := pmax.NewClientWithArgs("/", "test", true, true)
+        client, err := pmax.NewClientWithArgs("/", "test", true, true)
         if err != nil {
                 t.Fatalf("Faild to create a pmax client: %s", err.Error())
         }
+	Initialize([]string{"0001", "0002"}, client)
 
 	header := metadata.New(map[string]string{"csi.requestid": "1"})
 	ctx := metadata.NewIncomingContext(context.Background(), header)
 
-	var rep *ReplicationCapabilitiesCache
+	rep := ReplicationCapabilitiesCache{}
+	rep.CacheTime = 0
 
-        _, err = rep.Get(ctx, c, "0001")
+        _, err = rep.Get(ctx, client, "0001")
         if err != nil {
                 t.Errorf("Faied to create client with only primary managed array specified")
         }

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -64,9 +64,9 @@ func TestUpdate(t *testing.T) {
 		RdfCapable: true,
 	}
 	rep := ReplicationCapabilitiesCache{}
-        _, err = rep.update(symmetrixCapability)
-        if err != nil {
-                t.Errorf("update call failed with error %+v", err)
+        rep.update(symmetrixCapability)
+        if rep.cap != symmetrixCapability {
+                t.Errorf("update call failed -- capability not set")
         }
 }
 

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -64,7 +64,7 @@ func TestUpdate(t *testing.T) {
 	}
 	rep := ReplicationCapabilitiesCache{}
         rep.update(symmetrixCapability)
-        if rep.cap.SymmetrixID == "fakeSymmetrix" and rep.cap.SnapVxCapable and rep.cap.RdfCapable {
+        if rep.cap.SymmetrixID == "fakeSymmetrix" && rep.cap.SnapVxCapable && rep.cap.RdfCapable {
                 t.Errorf("update call failed -- capability not set")
         }
 }

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -71,7 +71,7 @@ func TestGet(t *testing.T) {
 
         _, err = rep.Get(ctx, client, "0001")
         if err != nil {
-                t.Errorf("Faied to create client with only primary managed array specified", err)
+                t.Errorf("Get call failed with error %+v", err)
         }
 }
 

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -58,19 +58,19 @@ func TestGetPowerMaxClient(t *testing.T) {
 // ctx context.Context, client pmax.Pmax, symID string
 func TestUpdate(t *testing.T) {
 	symmetrixCapability := types.SymmetrixCapability{
-		SymmetrixID: "fakeSymmetrix",
+		SymmetrixID:   "fakeSymmetrix",
 		SnapVxCapable: true,
-		RdfCapable: true,
+		RdfCapable:    true,
 	}
 	rep := ReplicationCapabilitiesCache{}
-        rep.update(&symmetrixCapability)
-        if rep.cap.SymmetrixID != "fakeSymmetrix" {
-                t.Errorf("update call failed -- SymmetrixID not set properly in capability: cap.SymmetrixID: %+v", rep.cap.SymmetrixID)
+	rep.update(&symmetrixCapability)
+	if rep.cap.SymmetrixID != "fakeSymmetrix" {
+		t.Errorf("update call failed -- SymmetrixID not set properly in capability: cap.SymmetrixID: %+v", rep.cap.SymmetrixID)
 		if !rep.cap.SnapVxCapable {
 			t.Errorf("update call failed -- SnapVxCapable not set properly in capability: cap.SnapVxCapable: %+v", rep.cap.SnapVxCapable)
 			if !rep.cap.RdfCapable {
 				t.Errorf("update call failed -- RdfCapable not set properly in capability: cap.RdfCapable: %+v", rep.cap.RdfCapable)
 			}
 		}
-        }
+	}
 }

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -66,7 +66,9 @@ func TestGet(t *testing.T) {
 	header := metadata.New(map[string]string{"csi.requestid": "1"})
 	ctx := metadata.NewIncomingContext(context.Background(), header)
 
-        _, err = ReplicationCapabilitiesCache.Get(ctx, c, "0001")
+	var rep *ReplicationCapabilitiesCache
+
+        _, err = rep.Get(ctx, c, "0001")
         if err != nil {
                 t.Errorf("Faied to create client with only primary managed array specified")
         }

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -65,7 +65,6 @@ func TestUpdate(t *testing.T) {
 	rep := ReplicationCapabilitiesCache{}
         rep.update(&symmetrixCapability)
         if rep.cap.SymmetrixID == "fakeSymmetrix" && rep.cap.SnapVxCapable && rep.cap.RdfCapable {
-                t.Errorf("update call failed -- capability not set")
+                t.Errorf("update call failed -- capability not set properly. SymmetrixID: %+v, rep.cap.SnapVxCapable: %+v, rep.cap.RdfCapable: %+v", rep.cap.SymmetrixID, rep.cap.SnapVxCapable, rep.cap.RdfCapable)
         }
 }
-

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -71,7 +71,7 @@ func TestGet(t *testing.T) {
 
         _, err = rep.Get(ctx, client, "0001")
         if err != nil {
-                t.Errorf("Faied to create client with only primary managed array specified")
+                t.Errorf("Faied to create client with only primary managed array specified", err)
         }
 }
 

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -19,9 +19,6 @@ import (
 
 	pmax "github.com/dell/gopowermax/v2"
 	types "github.com/dell/gopowermax/v2/types/v100"
-
-	"golang.org/x/net/context"
-	"google.golang.org/grpc/metadata"
 )
 
 func TestGetPowerMaxClient(t *testing.T) {
@@ -60,7 +57,7 @@ func TestGetPowerMaxClient(t *testing.T) {
 
 // ctx context.Context, client pmax.Pmax, symID string
 func TestUpdate(t *testing.T) {
-	symmetrixCapability = types.SymmetrixCapability{
+	symmetrixCapability := types.SymmetrixCapability{
 		SymmetrixID: "fakeSymmetrix",
 		SnapVxCapable: true,
 		RdfCapable: true,

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	pmax "github.com/dell/gopowermax/v2"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/metadata"
 )
 
 func TestGetPowerMaxClient(t *testing.T) {
@@ -53,3 +55,20 @@ func TestGetPowerMaxClient(t *testing.T) {
 		t.Errorf("Should have failed with none of the arrays managed")
 	}
 }
+
+// ctx context.Context, client pmax.Pmax, symID string
+func TestGet(t *testing.T) {
+        c, err := pmax.NewClientWithArgs("/", "test", true, true)
+        if err != nil {
+                t.Fatalf("Faild to create a pmax client: %s", err.Error())
+        }
+
+	header := metadata.New(map[string]string{"csi.requestid": "1"})
+	ctx := metadata.NewIncomingContext(context.Background(), header)
+
+        _, err = Get(ctx, c, "0001")
+        if err != nil {
+                t.Errorf("Faied to create client with only primary managed array specified")
+        }
+}
+

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -68,7 +68,6 @@ func TestGet(t *testing.T) {
 	ctx := metadata.NewIncomingContext(context.Background(), header)
 
 	rep := ReplicationCapabilitiesCache{}
-	rep.CacheTime = 0
 
         _, err = rep.Get(ctx, client, "0001")
         if err != nil {

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -63,6 +63,7 @@ func TestUpdate(t *testing.T) {
 		SnapVxCapable: true,
 		RdfCapable: true,
 	}
+	rep := ReplicationCapabilitiesCache{}
         _, err = rep.update(symmetrixCapability)
         if err != nil {
                 t.Errorf("update call failed with error %+v", err)

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -57,7 +57,7 @@ func TestGetPowerMaxClient(t *testing.T) {
 
 // ctx context.Context, client pmax.Pmax, symID string
 func TestUpdate(t *testing.T) {
-	symmetrixCapability := types.SymmetrixCapability{
+	symmetrixCapability := &types.SymmetrixCapability{
 		SymmetrixID: "fakeSymmetrix",
 		SnapVxCapable: true,
 		RdfCapable: true,

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -57,13 +57,13 @@ func TestGetPowerMaxClient(t *testing.T) {
 
 // ctx context.Context, client pmax.Pmax, symID string
 func TestUpdate(t *testing.T) {
-	symmetrixCapability := &types.SymmetrixCapability{
+	symmetrixCapability := types.SymmetrixCapability{
 		SymmetrixID: "fakeSymmetrix",
 		SnapVxCapable: true,
 		RdfCapable: true,
 	}
 	rep := ReplicationCapabilitiesCache{}
-        rep.update(symmetrixCapability)
+        rep.update(&symmetrixCapability)
         if rep.cap.SymmetrixID == "fakeSymmetrix" && rep.cap.SnapVxCapable && rep.cap.RdfCapable {
                 t.Errorf("update call failed -- capability not set")
         }

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -66,9 +66,9 @@ func TestUpdate(t *testing.T) {
         rep.update(&symmetrixCapability)
         if rep.cap.SymmetrixID == "fakeSymmetrix" {
                 t.Errorf("update call failed -- SymmetrixID not set properly in capability: cap.SymmetrixID: %+v", rep.cap.SymmetrixID)
-		if not rep.cap.SnapVxCapable {
+		if !rep.cap.SnapVxCapable {
 			t.Errorf("update call failed -- SnapVxCapable not set properly in capability: cap.SnapVxCapable: %+v", rep.cap.SnapVxCapable)
-			if not rep.cap.RdfCapable {
+			if !rep.cap.RdfCapable {
 				t.Errorf("update call failed -- RdfCapable not set properly in capability: cap.RdfCapable: %+v", rep.cap.RdfCapable)
 			}
 		}

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -64,7 +64,7 @@ func TestUpdate(t *testing.T) {
 	}
 	rep := ReplicationCapabilitiesCache{}
         rep.update(&symmetrixCapability)
-        if rep.cap.SymmetrixID == "fakeSymmetrix" {
+        if rep.cap.SymmetrixID != "fakeSymmetrix" {
                 t.Errorf("update call failed -- SymmetrixID not set properly in capability: cap.SymmetrixID: %+v", rep.cap.SymmetrixID)
 		if !rep.cap.SnapVxCapable {
 			t.Errorf("update call failed -- SnapVxCapable not set properly in capability: cap.SnapVxCapable: %+v", rep.cap.SnapVxCapable)

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -64,7 +64,13 @@ func TestUpdate(t *testing.T) {
 	}
 	rep := ReplicationCapabilitiesCache{}
         rep.update(&symmetrixCapability)
-        if rep.cap.SymmetrixID == "fakeSymmetrix" && rep.cap.SnapVxCapable && rep.cap.RdfCapable {
-                t.Errorf("update call failed -- capability not set properly. SymmetrixID: %+v, rep.cap.SnapVxCapable: %+v, rep.cap.RdfCapable: %+v", rep.cap.SymmetrixID, rep.cap.SnapVxCapable, rep.cap.RdfCapable)
+        if rep.cap.SymmetrixID == "fakeSymmetrix" {
+                t.Errorf("update call failed -- SymmetrixID not set properly in capability: cap.SymmetrixID: %+v", rep.cap.SymmetrixID)
+		if not rep.cap.SnapVxCapable {
+			t.Errorf("update call failed -- SnapVxCapable not set properly in capability: cap.SnapVxCapable: %+v", rep.cap.SnapVxCapable)
+			if not rep.cap.RdfCapable {
+				t.Errorf("update call failed -- RdfCapable not set properly in capability: cap.RdfCapable: %+v", rep.cap.RdfCapable)
+			}
+		}
         }
 }

--- a/pkg/symmetrix/powermax_test.go
+++ b/pkg/symmetrix/powermax_test.go
@@ -57,21 +57,15 @@ func TestGetPowerMaxClient(t *testing.T) {
 }
 
 // ctx context.Context, client pmax.Pmax, symID string
-func TestGet(t *testing.T) {
-        client, err := pmax.NewClientWithArgs("/", "test", true, true)
+func TestUpdate(t *testing.T) {
+	symmetrixCapability = SymmetrixCapability{
+		SymmetrixID: "fakeSymmetrix",
+		SnapVxCapable: true,
+		RdfCapable: true,
+	}
+        _, err = rep.update(symmetrixCapability)
         if err != nil {
-                t.Fatalf("Faild to create a pmax client: %s", err.Error())
-        }
-	Initialize([]string{"0001", "0002"}, client)
-
-	header := metadata.New(map[string]string{"csi.requestid": "1"})
-	ctx := metadata.NewIncomingContext(context.Background(), header)
-
-	rep := ReplicationCapabilitiesCache{}
-
-        _, err = rep.Get(ctx, client, "0001")
-        if err != nil {
-                t.Errorf("Get call failed with error %+v", err)
+                t.Errorf("update call failed with error %+v", err)
         }
 }
 

--- a/test/integration/step_defs_test.go
+++ b/test/integration/step_defs_test.go
@@ -1542,11 +1542,11 @@ func (f *feature) allVolumesAreDeletedSuccessfully() error {
 		symVolumeID := idComponents[len(idComponents)-1]
 		symID := idComponents[len(idComponents)-2]
 		fmt.Printf("Waiting for volume %s %s to be deleted\n", id, symVolumeID)
-		max := 40 * nVols
-		if 300 > max {
-			max = 300
+		maxVols := 40 * nVols
+		if 300 > maxVols {
+			maxVols = 300
 		}
-		for i := 0; i < max; i++ {
+		for i := 0; i < maxVols; i++ {
 			vol, err := f.pmaxClient.GetVolumeByID(context.Background(), symID, symVolumeID)
 			if vol == nil {
 				deleted = strings.Contains(err.Error(), "Could not find")


### PR DESCRIPTION
# Description
The sample secret names used in the sample reverseproxy configmap yaml are unclear. This PR makes it clear which endpoint each secret is for. There is an accompanying doc PR for this clarification.

Additionally, a few unrelated variable names were changed to comply with linting, and I added a unit test to cover the code where I changed the variable name.

# GitHub Issues
| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1568 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Ran unit tests for both driver and reverseproxy. No integration tests run because these changes are not touched by integration tests (there are no code changes).