### PR TITLE
Updating default value for X_CSI_TRANSPORT_PROTOCOL

### DIFF
--- a/samples/configmap/powermax-array-config.yaml
+++ b/samples/configmap/powermax-array-config.yaml
@@ -19,7 +19,7 @@ data:
   powermax-array-config.yaml: |
     # List of comma-separated port groups (ISCSI only). Example: PortGroup1, portGroup2 Required for iSCSI only
     X_CSI_POWERMAX_PORTGROUPS: ""
-    # Choose which transport protocol to use (ISCSI, FC, NVMETCP, auto) defaults to auto if nothing is specified
+    # Choose which transport protocol to use (ISCSI, FC, NVMETCP or auto) defaults to auto if nothing is specified
     X_CSI_TRANSPORT_PROTOCOL: ""
     # IP address of the Unisphere for PowerMax (Required), Defaults to https://0.0.0.0:8443
     X_CSI_POWERMAX_ENDPOINT: "https://10.0.0.0:8443"

--- a/samples/configmap/powermax-array-config.yaml
+++ b/samples/configmap/powermax-array-config.yaml
@@ -19,7 +19,7 @@ data:
   powermax-array-config.yaml: |
     # List of comma-separated port groups (ISCSI only). Example: PortGroup1, portGroup2 Required for iSCSI only
     X_CSI_POWERMAX_PORTGROUPS: ""
-    # Choose which transport protocol to use (ISCSI, FC, NVMETCP, auto or None) defaults to auto if nothing is specified
+    # Choose which transport protocol to use (ISCSI, FC, NVMETCP, auto) defaults to auto if nothing is specified
     X_CSI_TRANSPORT_PROTOCOL: ""
     # IP address of the Unisphere for PowerMax (Required), Defaults to https://0.0.0.0:8443
     X_CSI_POWERMAX_ENDPOINT: "https://10.0.0.0:8443"


### PR DESCRIPTION
# Description
Updating default value for X_CSI_TRANSPORT_PROTOCOL in the comment section of powermax-array-config.yaml

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1638|

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [X] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
