### PR TITLE
Snapshot License cache fix

### DIFF
--- a/service/features/snapshot.feature
+++ b/service/features/snapshot.feature
@@ -6,13 +6,16 @@ Feature: PowerMax CSI Interface
     Scenario: Snapshot license
         Given a PowerMax service
         When I check the snapshot license
-        And I reset the license cache
         Then no error was received
+        And the snapshot license cache has "1" array
+        And I reset the license cache
+        And the snapshot license cache has "0" array
 @v1.2.0
     Scenario: Snapshot license for unlicensed array
         Given a PowerMax service
         And I induce error "SnapshotNotLicensed"
         When I check the snapshot license
+        And the snapshot license cache has "1" array
         And I reset the license cache
         Then the error contains "doesn't have Snapshot license"
 @v1.2.0
@@ -20,6 +23,7 @@ Feature: PowerMax CSI Interface
         Given a PowerMax service
         And I induce error "InvalidResponse"
         When I check the snapshot license
+        And the snapshot license cache has "0" array
         And I reset the license cache
         Then the error contains "induced error"
 @v1.2.0
@@ -27,6 +31,7 @@ Feature: PowerMax CSI Interface
         Given a PowerMax service
         And I induce error "UnisphereMismatchError"
         When I check the snapshot license
+        And the snapshot license cache has "0" array
         And I reset the license cache
         Then the error contains "not being managed by Unisphere"
 @v1.2.0

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3929,7 +3929,10 @@ func (f *feature) noVolumeSource() error {
 }
 
 func (f *feature) iResetTheLicenseCache() error {
-	symmRepCapabilities = nil
+	for k := range symmRepCapabilities {
+		delete(symmRepCapabilities, k)
+	}
+
 	return nil
 }
 

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3928,6 +3928,13 @@ func (f *feature) noVolumeSource() error {
 	return nil
 }
 
+func (f *feature) validateSnapshotLicenseCache(count int) error {
+	if len(symmRepCapabilities) != count {
+		return fmt.Errorf("Expected %d array(s) in the license cache but got %d", count, len(symmRepCapabilities))
+	}
+	return nil
+}
+
 func (f *feature) iResetTheLicenseCache() error {
 	for k := range symmRepCapabilities {
 		delete(symmRepCapabilities, k)
@@ -5145,6 +5152,7 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^a valid DeleteSnapshotResponse is returned$`, f.aValidDeleteSnapshotResponseIsReturned)
 	s.Step(`^a non-existent volume$`, f.aNonexistentVolume)
 	s.Step(`^no volume source$`, f.noVolumeSource)
+	s.Step(`^the snapshot license cache has "(\d+)" array$`, f.validateSnapshotLicenseCache)
 	s.Step(`^I reset the license cache$`, f.iResetTheLicenseCache)
 	s.Step(`^I call IsSnapshotSource$`, f.iCallIsSnapshotSource)
 	s.Step(`^IsSnapshotSource returns "([^"]*)"$`, f.isSnapshotSourceReturns)

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3929,7 +3929,6 @@ func (f *feature) noVolumeSource() error {
 }
 
 func (f *feature) iResetTheLicenseCache() error {
-	licenseCached = false
 	symmRepCapabilities = nil
 	return nil
 }


### PR DESCRIPTION
# Description

- Fixed Snapshot License cache.
- Earlier, when the capabilities request to Unisphere is made for an array, the driver considers caches that information and used the same even for other arrays. This becomes an issue if the other array is managed by another Unisphere.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| TO-DO|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
On a setup with 2 arrays that are managed by different Unisphere instances, the issue was reproducible. And then with the fix, the issue is not observed. Clone volume was successfully created.
Please refer the ticket (31001) for test log and screenshots.

TO-DO cert-csi test results.

Before:
```
[root@master-1-0BX8wDGBJidld csm]# k get pvc -A
NAMESPACE   NAME            STATUS    VOLUME            CAPACITY     ACCESS MODES   STORAGECLASS         VOLUMEATTRIBUTESCLASS   AGE
nsps1       pvcps1          Bound     pmax-28fdfaef98   8390400Ki    RWO            powermax-iscsi-602   <unset>                 73m
nsps2       pvcps1          Bound     pmax-a18af3bc32   10487040Ki   RWO            powermax-iscsi-836   <unset>                 57m
nsps2       pvcps1-cloned   Pending                                                 powermax-iscsi-836   <unset>                 3m18s
[root@master-1-0BX8wDGBJidld csm]#
[root@master-1-0BX8wDGBJidld csm]# k describe pvc pvcps1-cloned -n nsps2
Events:
  Normal   Provisioning          59s (x9 over 3m9s)   csi-powermax.dellemc.com_powermax-controller-79b8c76dcc-gz44r_bfad7f04-3aa3-4347-b520-ba1dab3b7a5e  External provisioner is provisioning volume for claim "nsps2/pvcps1-cloned"
  Warning  ProvisioningFailed    59s (x9 over 3m7s)   csi-powermax.dellemc.com_powermax-controller-79b8c76dcc-gz44r_bfad7f04-3aa3-4347-b520-ba1dab3b7a5e  failed to provision volume with StorageClass "powermax-iscsi-836": rpc error: code = Internal desc = PowerMax array (000120001836) is not being managed by Unisphere
```

After:
```
[root@master-1-0BX8wDGBJidld ~]# k get pvc -A
NAMESPACE   NAME            STATUS   VOLUME            CAPACITY     ACCESS MODES   STORAGECLASS         VOLUMEATTRIBUTESCLASS   AGE
nsps1       pvcps1          Bound    pmax-28fdfaef98   8390400Ki    RWO            powermax-iscsi-602   <unset>                 6d
nsps2       pvcps1          Bound    pmax-a18af3bc32   10487040Ki   RWO            powermax-iscsi-836   <unset>                 6d
nsps2       pvcps1-cloned   Bound    pmax-6d1f4c3525   10487040Ki   RWO            powermax-iscsi-836   <unset>                 5d23h
[root@master-1-0BX8wDGBJidld ~]#
[root@master-1-0BX8wDGBJidld ~]# k get pv
NAME              CAPACITY     ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                 STORAGECLASS         VOLUMEATTRIBUTESCLASS   REASON   AGE
pmax-28fdfaef98   8390400Ki    RWO            Delete           Bound    nsps1/pvcps1          powermax-iscsi-602   <unset>                          6d
pmax-6d1f4c3525   10487040Ki   RWO            Delete           Bound    nsps2/pvcps1-cloned   powermax-iscsi-836   <unset>                          2m53s
pmax-a18af3bc32   10487040Ki   RWO            Delete           Bound    nsps2/pvcps1          powermax-iscsi-836   <unset>                          6d
[root@master-1-0BX8wDGBJidld ~]#
```