### PR TITLE
Ignore case difference for host name when X_CSI_IG_MODIFY_HOSTNAME is enabled

### DIFF
--- a/service/features/node_publish_unpublish.feature
+++ b/service/features/node_publish_unpublish.feature
@@ -523,6 +523,7 @@ Feature: PowerMax CSI interface
     |node1          | node2                    | nvalid          | induced                                  | errormsg                                            |
     |"host1"        | "host2"                  | 0               | "none"                                   | "is already a part of a different host"             |
     |"host1"        | "host1"                  | 1               | "none"                                   | "none"                                              |
+    |"host1"        | "HOST1"                  | 1               | "none"                                   | "none"                                              |
     |"host1"        | "host1"                  | 0               | "GetInitiatorByIDError"                  | "none"                                              |
 
 @v1.4.0
@@ -542,6 +543,7 @@ Feature: PowerMax CSI interface
     |"host1"        | "host1"   | 1        | false    | "temp-csi-%host1%"        | "none"                    | "none"                                              |
     |"host1"        | "host1"   | 0        | false    | "temp-csi-%host1%"        | "GetInitiatorByIDError"   | "none"                                              |
     |"host1"        | "host2"   | 0        | false    | "temp.!csi-%host1%"       | "none"                    | "is already a part of a different host"             |
+    |"host1"        | "HOST1"   | 1        | true     | "temp-csi-%host1%"        | "UpdateHostError"         | "none"                                              |
     |"host1"        | "host2"   | 1        | true     | "temp-csi-%host1%"        | "none"                    | "none"                                              |
     |"host1"        | "host2"   | 0        | true     | "temp-csi-%host1%"        | "UpdateHostError"         | "Error updating Host"                               |
     |"host1"        | "host2"   | 1        | true     | "temp-csi-%host1"         | "none"                    | "none"                                              |

--- a/service/node.go
+++ b/service/node.go
@@ -1654,35 +1654,33 @@ func (s *service) verifyAndUpdateInitiatorsInADiffHost(ctx context.Context, symI
 					continue
 				}
 				if initiator.Host != "" {
-					initiatorHostLower := strings.ToLower(initiator.Host)
-					hostIDLower := strings.ToLower(hostID)
-
-					if initiatorHostLower != hostIDLower &&
-						s.opts.ModifyHostName {
-						if !hostUpdated {
-							// User has set ModifyHostName to modify host name in case of a mismatch
-							log.Infof("UpdateHostName processing: %s to %s", initiator.Host, hostID)
-							_, err := pmaxClient.UpdateHostName(ctx, symID, initiator.Host, hostID)
-							if err != nil {
-								errormsg = fmt.Sprintf("Failed to change host name from %s to %s: %s", initiator.HostID, hostID, err)
+					if !strings.EqualFold(initiator.Host, hostID) {
+						if s.opts.ModifyHostName {
+							if !hostUpdated {
+								// User has set ModifyHostName to modify host name in case of a mismatch
+								log.Infof("UpdateHostName processing: %s to %s", initiator.Host, hostID)
+								_, err := pmaxClient.UpdateHostName(ctx, symID, initiator.Host, hostID)
+								if err != nil {
+									errormsg = fmt.Sprintf("Failed to change host name from %s to %s: %s", initiator.Host, hostID, err)
+									log.Warning(errormsg)
+									continue
+								}
+								hostUpdated = true
+							} else {
+								errormsg = fmt.Sprintf("Skipping Updating Host %s for initiator: %s as updated host already present on: %s", initiator.Host,
+									initiatorID, symID)
 								log.Warning(errormsg)
 								continue
 							}
-							hostUpdated = true
 						} else {
-							errormsg = fmt.Sprintf("Skipping Updating Host %s for initiator: %s as updated host already present on: %s", initiator.HostID,
-								initiatorID, symID)
+							errormsg = fmt.Sprintf("initiator: %s is already a part of a different host: %s on: %s",
+								initiatorID, initiator.Host, symID)
 							log.Warning(errormsg)
 							continue
 						}
-					} else if initiatorHostLower != hostIDLower {
-						errormsg = fmt.Sprintf("initiator: %s is already a part of a different host: %s on: %s",
-							initiatorID, initiator.Host, symID)
-						log.Warning(errormsg)
-						continue
 					}
 				}
-				log.Infof("valid initiator: %s\n", initiatorID)
+				log.Infof("Valid initiator: %s", initiatorID)
 				validInitiators = appendIfMissing(validInitiators, nodeInitiator)
 				errormsg = ""
 			}

--- a/service/node.go
+++ b/service/node.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/service/node.go
+++ b/service/node.go
@@ -1654,7 +1654,10 @@ func (s *service) verifyAndUpdateInitiatorsInADiffHost(ctx context.Context, symI
 					continue
 				}
 				if initiator.Host != "" {
-					if initiator.Host != hostID &&
+					initiatorHostLower := strings.ToLower(initiator.Host)
+					hostIDLower := strings.ToLower(hostID)
+
+					if initiatorHostLower != hostIDLower &&
 						s.opts.ModifyHostName {
 						if !hostUpdated {
 							// User has set ModifyHostName to modify host name in case of a mismatch
@@ -1672,7 +1675,7 @@ func (s *service) verifyAndUpdateInitiatorsInADiffHost(ctx context.Context, symI
 							log.Warning(errormsg)
 							continue
 						}
-					} else if initiator.Host != hostID {
+					} else if initiatorHostLower != hostIDLower {
 						errormsg = fmt.Sprintf("initiator: %s is already a part of a different host: %s on: %s",
 							initiatorID, initiator.Host, symID)
 						log.Warning(errormsg)

--- a/service/storage_group_svc.go
+++ b/service/storage_group_svc.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -571,7 +571,7 @@ func (g *storageGroupSvc) addVolumesToSGMV(ctx context.Context, reqID, symID, tg
 	if maskingViewExists {
 		// We just need to confirm if all the other entities are in order
 		// Check for host group too in case of vsphere
-		if (tgtMaskingView.HostID == hostID || tgtMaskingView.HostGroupID == hostID) && tgtMaskingView.StorageGroupID == tgtStorageGroupID {
+		if (strings.EqualFold(tgtMaskingView.HostID, hostID) || strings.EqualFold(tgtMaskingView.HostGroupID, hostID)) && strings.EqualFold(tgtMaskingView.StorageGroupID, tgtStorageGroupID) {
 			// Add the volumes to masking view, if any to be added
 			if len(devIDs) > 0 {
 				log.WithFields(f).Info("Calling AddVolumesToStorageGroup")


### PR DESCRIPTION
# Description
Ignored case difference for host name when X_CSI_IG_MODIFY_HOSTNAME is enabled. So, existing host with different case will be considered instead of modifying it which fails.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1650 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
The issue was reproduced on my setup and the node pod crashed.
Then with the fix on the same setup, the node pod didn't crash. 
```
time="2024-12-19T21:49:29Z" level=info msg="**************************nodeHostSetup executing...*******************************"
time="2024-12-19T21:49:29Z" level=info msg="Waiting for 10 seconds"
time="2024-12-19T21:49:39Z" level=info msg="valid FC initiators: []"
time="2024-12-19T21:49:39Z" level=info msg="No existing NVMe hosts; new hosts will be created for all discovered initiators"
time="2024-12-19T21:49:39Z" level=info msg="valid NVMeTCP initiators: []"
time="2024-12-19T21:49:39Z" level=info msg="Checking initiator OR-1C:000:iqn.1994-05.com.redhat:00001 against host csi-node-SL-worker-1-0bx8wdgbjidld"
time="2024-12-19T21:49:39Z" level=info msg="Valid initiator: OR-1C:000:iqn.1994-05.com.redhat:00001"
time="2024-12-19T21:49:39Z" level=info msg="valid (existing) iSCSI initiators (must be manually created): [iqn.1994-05.com.redhat:00001]"
time="2024-12-19T21:49:39Z" level=info msg="ISCSI Daemon is active"
time="2024-12-19T21:49:39Z" level=info msg="setting up array 000000000001 for Iscsi, host name: csi-node-SL-worker-1-0bx8wdgbjidld masking view ID: csi-mv-SL-worker-1-0bx8wdgbjidld"
time="2024-12-19T21:49:39Z" level=debug msg="Processing Iscsi Host array: 000000000001, nodeName: csi-node-SL-worker-1-0bx8wdgbjidld, initiators: [iqn.1994-05.com.redhat:00001]"
time="2024-12-19T21:49:39Z" level=info msg="GetHostById returned: &{csi-node-sl-WORKER-1-0bx8wdgbjidld 0 1 0 false false   iSCSI [iqn.1994-05.com.redhat:00001] [] [] 0 0}, <nil>" 
```
Able to provision with that worker node, no issues observed.

cert-csi basic test suites have passed. Output attached to ticket KRV-30759.