### PR TITLE
Add preflight required labels.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2020-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,10 +30,12 @@ COPY --from=builder /go/src/csi-powermax .
 COPY "csi-powermax.sh" .
 ENTRYPOINT ["/csi-powermax.sh"]
 RUN chmod +x /csi-powermax.sh
-LABEL vendor="Dell Inc." \
+LABEL vendor="Dell Technologies" \
+    maintainer="Dell Technologies" \
     name="csi-powermax" \
     summary="CSI Driver for Dell EMC PowerMax" \
     description="CSI Driver for provisioning persistent storage from Dell EMC PowerMax" \
-    version="2.12.0" \
+    release="1.13.0" \
+    version="2.13.0" \
     license="Apache-2.0"
 COPY ./licenses /licenses

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/csireverseproxy/Dockerfile
+++ b/csireverseproxy/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright © 2020 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2020-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,12 +48,14 @@ RUN CGO_ENABLED=0 go build
 # STEP 2 build a small image
 ############################
 FROM $BASEIMAGE as final
-LABEL vendor="Dell Inc." \
-      name="csipowermax-reverseproxy" \
-      summary="CSI PowerMax Reverse Proxy" \
-      description="CSI PowerMax Reverse Proxy which helps manage connections with Unisphere for PowerMax" \
-      version="2.11.0" \
-      license="Apache-2.0"
+LABEL vendor="Dell Technologies" \
+    maintainer="Dell Technologies" \
+    name="csipowermax-reverseproxy" \
+    summary="CSI PowerMax Reverse Proxy" \
+    description="CSI PowerMax Reverse Proxy which helps manage connections with Unisphere for PowerMax" \
+    release="1.13.0" \
+    version="2.12.0" \
+    license="Apache-2.0"
 COPY licenses /licenses
 # Import from builder.
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/csireverseproxy/Dockerfile
+++ b/csireverseproxy/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2020-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description
Added the required labels to the image container so that it can pass preflight checks.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1667 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Built images. Docker inspect show:

          "Labels": {
               "architecture": "x86_64",
               "build-date": "2024-08-27T19:24:54",
               "com.redhat.component": "ubi9-micro-container",
               "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
               "description": "CSI Driver for provisioning persistent storage from Dell EMC PowerMax",
               "distribution-scope": "public",
               "io.buildah.version": "1.29.4",
               "io.k8s.description": "Very small image which doesn't install the package manager.",
               "io.k8s.display-name": "Ubi9-micro",
               "io.openshift.expose-services": "",
               "license": "Apache-2.0",
               "maintainer": "Dell Technologies",
               "name": "csi-powermax",
               "release": "1.13.0",
               "summary": "CSI Driver for Dell EMC PowerMax",
               "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/ubi-micro/images/9.4-15",
               "vcs-ref": "cd5996c9b8b99b546584696465f8f39ec682078c",
               "vcs-type": "git",
               "vendor": "Dell Technologies",
               "version": "2.13.0"
          },
          
         "Labels": {
               "architecture": "x86_64",
               "build-date": "2024-08-27T19:24:54",
               "com.redhat.component": "ubi9-micro-container",
               "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
               "description": "CSI PowerMax Reverse Proxy which helps manage connections with Unisphere for PowerMax",
               "distribution-scope": "public",
               "io.buildah.version": "1.29.4",
               "io.k8s.description": "Very small image which doesn't install the package manager.",
               "io.k8s.display-name": "Ubi9-micro",
               "io.openshift.expose-services": "",
               "license": "Apache-2.0",
               "maintainer": "Dell Technologies",
               "name": "csipowermax-reverseproxy",
               "release": "1.13.0",
               "summary": "CSI PowerMax Reverse Proxy",
               "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/ubi-micro/images/9.4-15",
               "vcs-ref": "cd5996c9b8b99b546584696465f8f39ec682078c",
               "vcs-type": "git",
               "vendor": "Dell Technologies",
               "version": "2.12.0"
          },
     
