### PR TITLE
Fixed DeleteStorageProtectionGroup function response

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -3945,7 +3945,7 @@ func (s *service) DeleteStorageProtectionGroup(ctx context.Context, req *csiext.
 	}
 	sg, err := pmaxClient.GetProtectedStorageGroup(ctx, symID, protectionGroupID)
 	if err != nil {
-		if strings.Contains(err.Error(), cannotBeFound) {
+		if strings.Contains(err.Error(), cannotBeFound) || strings.Contains(err.Error(), "cannot be found") {
 			// The protected storage group is already deleted
 			log.Info(fmt.Sprintf("DeleteStorageProtectionGroup: Could not find protected SG: %s on SymID: %s so assume it's already deleted", protectionGroupID, symID))
 			return &csiext.DeleteStorageProtectionGroupResponse{}, nil


### PR DESCRIPTION
# Description
When we delete rg from cluster it is getting stuck in deleting state because of mismatch in the response from error message so added the correct string now in DeleteStorageProtectionGroup function.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
