### PR TITLE
Metro: Set default value for replication prefixes

### DIFF
--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -412,6 +412,12 @@ Feature: PowerMax CSI interface
       When I call BeforeServe with an invalid ClusterPrefix
       Then the error contains "exceeds maximum length"
 
+@v2.14.0
+     Scenario: Test BeforeServe
+      Given a PowerMax service
+      When I call BeforeServe
+      Then replication prefixes have default values
+
 @v1.0.0
      Scenario: Call ListVolumes, should get unimplemented
       Given a PowerMax service

--- a/service/service.go
+++ b/service/service.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -68,6 +68,8 @@ const (
 	CSILogFormatParam          = "CSI_LOG_FORMAT"
 	ArrayStatus                = "/array-status"
 	DefaultPodmonPollRate      = 60
+	ReplicationContextPrefix   = "powermax"
+	ReplicationPrefix          = "replication.storage.dell.com"
 	PortGroups                 = "X_CSI_POWERMAX_PORTGROUPS"
 	Protocol                   = "X_CSI_TRANSPORT_PROTOCOL"
 	// PmaxEndPoint               = "X_CSI_POWERMAX_ENDPOINT"
@@ -424,11 +426,16 @@ func (s *service) BeforeServe(
 		opts.KubeConfigPath = kubeConfigPath
 	}
 
+	// set default values for replication prefix since replicator sidecar is not needed for Metro feature.
 	if replicationContextPrefix, ok := csictx.LookupEnv(ctx, EnvReplicationContextPrefix); ok {
 		opts.ReplicationContextPrefix = replicationContextPrefix
+	} else {
+		opts.ReplicationContextPrefix = ReplicationContextPrefix
 	}
 	if replicationPrefix, ok := csictx.LookupEnv(ctx, EnvReplicationPrefix); ok {
 		opts.ReplicationPrefix = replicationPrefix
+	} else {
+		opts.ReplicationPrefix = ReplicationPrefix
 	}
 
 	if MaxVolumesPerNode, ok := csictx.LookupEnv(ctx, EnvMaxVolumesPerNode); ok {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -51,7 +51,7 @@ func TestGoDog(t *testing.T) {
 	runOptions := godog.Options{
 		Format: "pretty",
 		Paths:  []string{"features"},
-		Tags:   "v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.6.0, v2.2.0, v2.3.0, v2.4.0, v2.5.0, v2.6.0, v2.7.0, v2.8.0, v2.9.0, v2.11.0, v2.12.0, v2.13.0",
+		Tags:   "v1.0.0, v1.1.0, v1.2.0, v1.3.0, v1.4.0, v1.5.0, v1.6.0, v2.2.0, v2.3.0, v2.4.0, v2.5.0, v2.6.0, v2.7.0, v2.8.0, v2.9.0, v2.11.0, v2.12.0, v2.13.0, v2.14.0",
 		// Tags:   "wip",
 		// Tags: "resiliency", // uncomment to run all node resiliency related tests,
 	}

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -2720,6 +2720,15 @@ func (f *feature) iCallBeforeServeWithTopologyConfigSetAt(path string) error {
 	return nil
 }
 
+func (f *feature) verifyDefaultReplicationPrefix() error {
+	opts := f.service.opts
+	if opts.ReplicationPrefix != "replication.storage.dell.com" || opts.ReplicationContextPrefix != "powermax" {
+		return fmt.Errorf("expected default replication prefix, got %s %s", opts.ReplicationPrefix, opts.ReplicationContextPrefix)
+	}
+
+	return nil
+}
+
 func (f *feature) iCallNodeStageVolume() error {
 	//	_ = f.getNodePublishVolumeRequest()
 	header := metadata.New(map[string]string{"csi.requestid": "1"})
@@ -5056,6 +5065,7 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^I call BeforeServe$`, f.iCallBeforeServe)
 	s.Step(`^I call BeforeServe without ClusterPrefix$`, f.iCallBeforeServeWithoutClusterPrefix)
 	s.Step(`^I call BeforeServe with an invalid ClusterPrefix$`, f.iCallBeforeServeWithAnInvalidClusterPrefix)
+	s.Step(`^replication prefixes have default values$`, f.verifyDefaultReplicationPrefix)
 	s.Step(`^I call NodeStageVolume$`, f.iCallNodeStageVolume)
 	s.Step(`^I call NodeUnstageVolume$`, f.iCallNodeUnstageVolume)
 	s.Step(`^I call NodeStageVolume with simulator$`, f.iCallNodeStageVolumeWithSimulator)


### PR DESCRIPTION
# Description
Set default values for replication prefix in the driver since replicator sidecar is not needed for Metro feature.
With this, the driver will not fail the Metro request irrespective of the deployment method used.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1711 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation [TBA - revert Doc notes]
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?

Metro volume was created successfully and then deleted, with just the driver installed without the replication module or the replicator sidecar.

```
[root@koc1-bastion-10-247-96-100 powermax_309_836]# k get pv | grep metro
csivol-d642603e51   10487040Ki   RWO            Delete           Bound         default/my-pvc  
                                                 powermax-metro              <unset>                          13m
[root@koc1-bastion-10-247-96-100 powermax_309_836]# k get pvc | grep metro
my-pvc                        Bound         csivol-d642603e51   10487040Ki   RWO            powermax-metro              <unset>                 13m

[root@koc1-bastion-10-247-96-100 powermax_309_836]# k get pod | grep my-pod
my-pod                       1/1     Running     0               13m
```