### PR TITLE
Changes to revproxy to use mounted cm for params

### DIFF
--- a/csireverseproxy/pkg/common/constants.go
+++ b/csireverseproxy/pkg/common/constants.go
@@ -33,9 +33,9 @@ const (
 	EnvConfigDirName            = "X_CSI_REVPROXY_CONFIG_DIR"
 	EnvInClusterConfig          = "X_CSI_REVRPOXY_IN_CLUSTER"
 	EnvIsLeaderElectionEnabled  = "X_CSI_REVPROXY_IS_LEADER_ENABLED"
-	EnvSecretPath               = "X_CSI_REVPROXY_SECRET_FILEPATH"
-	EnvSecretName               = "X_CSI_REVPROXY_SECRET_NAME"
+	EnvSecretFilePath           = "X_CSI_REVPROXY_SECRET_FILEPATH"
 	EnvReverseProxyUseSecret    = "X_CSI_REVPROXY_USE_SECRET"
+	EnvPowermaxConfigPath       = "X_CSI_POWERMAX_CONFIG_PATH"
 	DefaultNameSpace            = "powermax"
 	MaxActiveReadRequests       = 5
 	MaxOutStandingWriteRequests = 50

--- a/csireverseproxy/pkg/config/config_test.go
+++ b/csireverseproxy/pkg/config/config_test.go
@@ -25,10 +25,11 @@ import (
 	"revproxy/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 )
 
 func readConfig() (*ProxyConfigMap, error) {
-	return ReadConfig(common.TestConfigFileName, "./../../"+common.TestConfigDir)
+	return ReadConfig(common.TestConfigFileName, "./../../"+common.TestConfigDir, viper.New())
 }
 
 func TestMain(m *testing.M) {

--- a/service/service.go
+++ b/service/service.go
@@ -635,16 +635,7 @@ func (s *service) BeforeServe(
 	// Start the deletion worker thread
 	log.Printf("s.mode: %s", s.mode)
 	if !strings.EqualFold(s.mode, "node") {
-		// TODO: Review this previously commented code and remove
-		/*symIDs, err := s.adminClient.GetSymmetrixIDList()
-		if err != nil {
-			return err
-		}
-		if len(symIDs.SymmetrixIDs) == 0 {
-			errMsg := "no arrays connected to the unisphere"
-			log.Println(errMsg)
-			return fmt.Errorf("%s", errMsg)
-		}*/
+	
 		s.NewDeletionWorker(s.opts.ClusterPrefix, s.opts.ManagedArrays)
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -635,7 +635,6 @@ func (s *service) BeforeServe(
 	// Start the deletion worker thread
 	log.Printf("s.mode: %s", s.mode)
 	if !strings.EqualFold(s.mode, "node") {
-	
 		s.NewDeletionWorker(s.opts.ClusterPrefix, s.opts.ManagedArrays)
 	}
 


### PR DESCRIPTION
# Description
1. Update reversepoxy to use powermax-config-params to infer port, log level etc. 
2. Simplified the watcher logic to use parameterized viper instances as opposed to global instances. 
3. Reverted back to throwing/return error when PrimaryEndpoint of a storage array does not have mapping entry under management servers.
4. Fixed prior review comments. 


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| (https://github.com/dell/csm/issues/1614)|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Manually tested mounted, secret and configmap cases with multiple arrays. Tested watcher logic by modifying params on the fly after the proxy is up and running. 
