### PR TITLE
csireverseproxy/pkg/k8sutils - UT improvements

### DIFF
--- a/csireverseproxy/main.go
+++ b/csireverseproxy/main.go
@@ -359,10 +359,10 @@ func run(ctx context.Context) {
 }
 
 func main() {
-	var kubeClient k8sutils.KubernetesClient
+
 	if isLEEnabled := getEnv(common.EnvIsLeaderElectionEnabled, "false"); isLEEnabled == "true" {
 		isInCluster := getEnv(common.EnvInClusterConfig, "false")
-		kubeClient, err := k8sutils.Init(common.DefaultNameSpace, common.DefaultCertDirName, isInCluster == "true", time.Second*30, &kubeClient)
+		kubeClient, err := k8sutils.Init(common.DefaultNameSpace, common.DefaultCertDirName, isInCluster == "true", time.Second*30, &k8sutils.KubernetesClient{})
 		if err != nil {
 			log.Fatalf("Failed to create kube client: [%s]", err.Error())
 		}


### PR DESCRIPTION
# Description
csireverseproxy/pkg/k8sutils - UT improvements to bring the coverage to > 90%

K8sUtils.go needed some refactoring to enable mocking of functions that rely on a really k8s cluster. Those functions are now injected. 


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Unit test: ok      revproxy/v2/pkg/k8sutils        0.347s  coverage: 91.4% of statements
cert-csi (with image built from this branch) : 
Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-02-06 17:19:57.780393693 +0000 UTC
            Ended:     2025-02-06 17:30:38.373937927 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCBind:
                        Avg: 17.382461335s
                        Min: 15.589933826s
                        Max: 20.551724538s
                        Histogram:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 29.41074961s
                        Min: 25.821657649s
                        Max: 30.510545947s
                        Histogram:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 20.078421ms
                        Min: 11.017222ms
                        Max: 28.940655ms
                        Histogram:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 48.76283745s
                        Min: 1.547998164s
                        Max: 2m14.31527196s
                        Histogram:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 1m9.01128671s
                        Min: 35.429748497s
                        Max: 1m44.787175865s
                        Histogram:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 15.365804695s
                        Min: 6.413416424s
                        Max: 26.706273431s
                        Histogram:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-4b20b09e/VolumeIoSuite6/EntityNumberOverTime.png

[2025-02-06 17:30:38]  INFO Avg time of a run:   626.82s
[2025-02-06 17:30:38]  INFO Avg time of a del:   12.01s
[2025-02-06 17:30:38]  INFO Avg time of all:     640.59s