### PR TITLE
csireverseproxy - improve UT coverage 

### DIFF
--- a/csireverseproxy/go.mod
+++ b/csireverseproxy/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gorilla/mux v1.7.3
 	github.com/kubernetes-csi/csi-lib-utils v0.9.1
+	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.7.0
+	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.20.0
 	k8s.io/apimachinery v0.20.0
@@ -34,7 +36,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/pelletier/go-toml v1.2.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cast v1.3.0 // indirect
 	github.com/spf13/jwalterweatherman v1.0.0 // indirect
@@ -51,6 +53,7 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.51.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 	k8s.io/klog/v2 v2.4.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd // indirect
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect

--- a/csireverseproxy/main_test.go
+++ b/csireverseproxy/main_test.go
@@ -396,7 +396,7 @@ func TestSignalHandlerOnConfigChange(t *testing.T) {
 	// sleep for 1 seconds to allow the configmap to be updated
 	time.Sleep(1 * time.Second)
 
-	// Failure case, lets create a new mgmt server with bad URL. 
+	// Failure case, lets create a new mgmt server with bad URL.
 	badManagementServer := config.ManagementServerConfig{
 		ArrayCredentialSecret:     proxySecretName,
 		URL:                       "://example.com/@",
@@ -409,6 +409,9 @@ func TestSignalHandlerOnConfigChange(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to update config map file. (%s)", err.Error())
 	}
+
+	// sleep for 1 seconds to allow the configmap to be updated
+	time.Sleep(1 * time.Second)
 	// Revert to original config for safety
 	cm.Config.ManagementServerConfig = originalConfig
 	err = writeYAMLConfig(cm, tmpSAConfigFile, common.TempConfigDir)

--- a/csireverseproxy/main_test.go
+++ b/csireverseproxy/main_test.go
@@ -16,9 +16,11 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -27,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -35,13 +38,20 @@ import (
 	"revproxy/v2/pkg/common"
 	"revproxy/v2/pkg/config"
 	"revproxy/v2/pkg/k8smock"
+	"revproxy/v2/pkg/k8sutils"
 	"revproxy/v2/pkg/servermock"
 	"revproxy/v2/pkg/utils"
 
+	"github.com/kubernetes-csi/csi-lib-utils/leaderelection"
+	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
 
 	"gopkg.in/yaml.v2"
 )
@@ -68,6 +78,7 @@ const (
 	primaryCertSecretName     = "cert-secret-4"
 	backupCertSecretName      = "cert-secret-9"
 	proxySecretName           = "proxy-secret-1"
+	proxySecretName2          = "proxy-secret-2"
 	storageArrayID            = "000000000001"
 	primaryPort               = "9104"
 	backupPort                = "9109"
@@ -86,6 +97,7 @@ func startTestServer() error {
 		return nil
 	}
 	k8sUtils := k8smock.Init()
+	os.Setenv(common.EnvInClusterConfig, "true")
 	serverOpts := getServerOpts()
 	serverOpts.ConfigDir = common.TempConfigDir
 	// Create test proxy config and start the server
@@ -95,6 +107,15 @@ func startTestServer() error {
 		return err
 	}
 	_, err = k8sUtils.CreateNewCredentialSecret(proxySecretName)
+	if err != nil {
+		return err
+	}
+
+	_, err = k8sUtils.CreateNewCredentialSecret(proxySecretName2)
+	if err != nil {
+		return err
+	}
+	_, err = k8sUtils.CreateNewCredentialSecret(primaryCertSecretName)
 	if err != nil {
 		return err
 	}
@@ -210,7 +231,7 @@ func stopServers() {
 func readYAMLConfig(filename, fileDir string) (config.ProxyConfigMap, error) {
 	configmap := config.ProxyConfigMap{}
 	file := filepath.Join(fileDir, filename)
-	yamlFile, err := ioutil.ReadFile(file)
+	yamlFile, err := os.ReadFile(file)
 	if err != nil {
 		return configmap, err
 	}
@@ -227,7 +248,7 @@ func writeYAMLConfig(val interface{}, fileName, fileDir string) error {
 		return err
 	}
 	filepath := filepath.Join(fileDir, fileName)
-	return ioutil.WriteFile(filepath, file, 0o777)
+	return os.WriteFile(filepath, file, 0o777)
 }
 
 func createTempConfig() error {
@@ -283,6 +304,7 @@ func createTempManagementServers() []config.ManagementServerConfig {
 	if !skipBackupCertValidation {
 		backupMgmntServer.CertSecret = backupCertSecretName
 	}
+
 	tempMgmtServerConfig := []config.ManagementServerConfig{primaryMgmntServer, backupMgmntServer}
 	return tempMgmtServerConfig
 }
@@ -333,6 +355,65 @@ func TestServer_Start(t *testing.T) {
 	err := startTestServer()
 	if err != nil {
 		t.Error(err.Error())
+	}
+}
+
+// Tests the configmap handler, needs a running server
+func TestSignalHandlerOnConfigChange(t *testing.T) {
+	log.Infof("Start CMHandlerTest")
+	defer log.Infof("End CMHandlerTest")
+
+	cm, err := readYAMLConfig(tmpSAConfigFile, common.TempConfigDir)
+	if err != nil {
+		t.Error("Failed to read config")
+		return
+	}
+
+	cm.LogLevel = "Debug"
+	cm.LogFormat = "json"
+	err = writeYAMLConfig(cm, tmpSAConfigFile, common.TempConfigDir)
+	if err != nil {
+		t.Error("Failed to write config")
+		return
+	}
+
+	log.Infof("Start CMHandlerTest - update secret to 2")
+	cm.Config.ManagementServerConfig[0].ArrayCredentialSecret = "proxy-secret-2"
+	err = writeYAMLConfig(cm, tmpSAConfigFile, common.TempConfigDir)
+	if err != nil {
+		t.Errorf("Failed to update config map file. (%s)", err.Error())
+	}
+	// sleep for 1 seconds to allow the configmap to be updated
+	time.Sleep(1 * time.Second)
+
+	log.Infof("Start CMHandlerTest - update secret to 1")
+
+	cm.Config.ManagementServerConfig[0].ArrayCredentialSecret = "proxy-secret-1"
+	err = writeYAMLConfig(cm, tmpSAConfigFile, common.TempConfigDir)
+	if err != nil {
+		t.Errorf("Failed to update config map file. (%s)", err.Error())
+	}
+	// sleep for 1 seconds to allow the configmap to be updated
+	time.Sleep(1 * time.Second)
+
+	// Failure case, lets create a new mgmt server with bad URL. 
+	badManagementServer := config.ManagementServerConfig{
+		ArrayCredentialSecret:     proxySecretName,
+		URL:                       "://example.com/@",
+		SkipCertificateValidation: true,
+	}
+
+	originalConfig := cm.Config.ManagementServerConfig
+	cm.Config.ManagementServerConfig = append(cm.Config.ManagementServerConfig, badManagementServer)
+	err = writeYAMLConfig(cm, tmpSAConfigFile, common.TempConfigDir)
+	if err != nil {
+		t.Errorf("Failed to update config map file. (%s)", err.Error())
+	}
+	// Revert to original config for safety
+	cm.Config.ManagementServerConfig = originalConfig
+	err = writeYAMLConfig(cm, tmpSAConfigFile, common.TempConfigDir)
+	if err != nil {
+		t.Errorf("Failed to update config map file. (%s)", err.Error())
 	}
 }
 
@@ -458,4 +539,394 @@ func TestSAHTTPRequest(t *testing.T) {
 		return
 	}
 	fmt.Printf("RESPONSE_BODY: %s\n", resp)
+}
+
+func TestMainFunc(t *testing.T) {
+	defaultRunFunc := runFunc
+	defaultGetKubeClientSetFunc := k8sInitFunc
+	defaultRunLeaderElectionFunc := runWithLeaderElectionFunc
+	defaultStartServerFunc := startServerFunc
+
+	afterEach := func() {
+		runFunc = defaultRunFunc
+		k8sInitFunc = defaultGetKubeClientSetFunc
+		runWithLeaderElectionFunc = defaultRunLeaderElectionFunc
+		startServerFunc = defaultStartServerFunc
+	}
+
+	runningCh := make(chan string)
+	tests := []struct {
+		name    string
+		setup   func()
+		want    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "execute main without leader election k8s init func failure",
+			setup: func() {
+				t.Setenv(common.EnvIsLeaderElectionEnabled, "false")
+				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
+					runningCh <- "not running"
+					return nil, errors.New("error, k8s init failed")
+				}
+			},
+			want:    "not running",
+			wantErr: true,
+			errMsg:  "should not be running",
+		},
+		{
+			name: "execute main() with leader election failure",
+			setup: func() {
+				t.Setenv(common.EnvIsLeaderElectionEnabled, "true")
+				t.Setenv(common.EnvWatchNameSpace, common.DefaultNameSpace)
+
+				startServerFunc = func(k8sUtils k8sutils.UtilsInterface, opts ServerOpts) (*Server, error) {
+					return &Server{
+						Opts: opts,
+					}, nil
+				}
+
+				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
+					return &k8sutils.K8sUtils{
+						KubernetesClient: k8sutils.KubernetesClient{
+							Clientset: fake.NewSimpleClientset(),
+						},
+					}, nil
+				}
+
+				runWithLeaderElectionFunc = func(_ *k8sutils.KubernetesClient) (err error) {
+					runningCh <- "not running"
+					ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+					defer cancel()
+
+					// Simulate leader election failure by setting lease duration > renew
+					lei := leaderelection.NewLeaderElection(fake.NewSimpleClientset(), "csi-powermax-reverse-proxy-dellemc-com", runFunc)
+					lei.WithRenewDeadline(10 * time.Second)
+					lei.WithLeaseDuration(5 * time.Second)
+					lei.WithContext(ctx)
+					lei.WithNamespace(getEnv(common.EnvWatchNameSpace, common.DefaultNameSpace))
+
+					// leader election Run() panics on failure, catch the panic and return an error
+					defer func() {
+						if r := recover(); r != nil {
+							log.Errorf("Leader election panicked: %v", r)
+							err = fmt.Errorf("%v, leader election failed due to panic: %v", err, r)
+						}
+					}()
+
+					err = lei.Run()
+					if err != nil {
+						t.Errorf("leader election failed as expected")
+					} else {
+						t.Errorf("expected leader election failure but got none")
+					}
+					return err
+				}
+			},
+			want:    "not running",
+			wantErr: true,
+			errMsg:  "should not be running",
+		},
+		{
+			name: "execute main() with leader election k8s init func failure",
+			setup: func() {
+				t.Setenv(common.EnvIsLeaderElectionEnabled, "true")
+				t.Setenv(common.EnvWatchNameSpace, common.DefaultNameSpace)
+
+				startServerFunc = func(k8sUtils k8sutils.UtilsInterface, opts ServerOpts) (*Server, error) {
+					return &Server{
+						Opts: opts,
+					}, nil
+				}
+
+				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
+					runningCh <- "not running"
+					return nil, errors.New("error, k8s init failed")
+				}
+			},
+			want:    "not running",
+			wantErr: true,
+			errMsg:  "should not be running",
+		},
+		{
+			name: "execute main() without leader election",
+			setup: func() {
+				t.Setenv(common.EnvIsLeaderElectionEnabled, "false")
+				startServerFunc = func(k8sUtils k8sutils.UtilsInterface, opts ServerOpts) (*Server, error) {
+					runningCh <- "running"
+					return &Server{
+						Opts: opts,
+					}, nil
+				}
+				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
+					return &k8sutils.K8sUtils{
+						KubernetesClient: k8sutils.KubernetesClient{
+							Clientset: fake.NewSimpleClientset(),
+						},
+					}, nil
+				}
+			},
+			want:    "running",
+			wantErr: false,
+		},
+		{
+			name: "execute main() with leader election",
+			setup: func() {
+				runFunc = func(_ context.Context) {
+					runningCh <- "running"
+				}
+
+				t.Setenv(common.EnvIsLeaderElectionEnabled, "true")
+				t.Setenv(common.EnvWatchNameSpace, common.DefaultNameSpace)
+
+				startServerFunc = func(k8sUtils k8sutils.UtilsInterface, opts ServerOpts) (*Server, error) {
+					return &Server{
+						Opts: opts,
+					}, nil
+				}
+
+				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
+					return &k8sutils.K8sUtils{
+						KubernetesClient: k8sutils.KubernetesClient{
+							Clientset: fake.NewSimpleClientset(),
+						},
+					}, nil
+				}
+			},
+			want:    "running",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer afterEach()
+			tt.setup()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+
+			go main()
+
+			select {
+			case running := <-runningCh:
+				switch running {
+				case "running":
+					if tt.want != "running" {
+						t.Errorf("main() = %v, want %v", running, tt.want)
+					}
+
+				case "not running":
+					if tt.want != "not running" {
+						t.Errorf("main() = %v, want %v", running, tt.want)
+					}
+				}
+			case <-ctx.Done():
+				t.Errorf("timed out waiting for driver to run")
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	defaultRunFunc := runFunc
+	defaultGetKubeClientSetFunc := k8sInitFunc
+	defaultRunLeaderElectionFunc := runWithLeaderElectionFunc
+	defaultStartServerFunc := startServerFunc
+
+	afterEach := func() {
+		runFunc = defaultRunFunc
+		k8sInitFunc = defaultGetKubeClientSetFunc
+		runWithLeaderElectionFunc = defaultRunLeaderElectionFunc
+		startServerFunc = defaultStartServerFunc
+	}
+
+	runningCh := make(chan string)
+	tests := []struct {
+		name    string
+		setup   func()
+		want    string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "execute run sucess",
+			setup: func() {
+
+				t.Setenv(common.EnvIsLeaderElectionEnabled, "false")
+				startServerFunc = func(k8sUtils k8sutils.UtilsInterface, opts ServerOpts) (*Server, error) {
+					return &Server{
+						Opts: opts,
+					}, nil
+				}
+				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
+					return &k8sutils.K8sUtils{
+						KubernetesClient: k8sutils.KubernetesClient{
+							Clientset: fake.NewSimpleClientset(),
+						},
+					}, nil
+				}
+				runFunc = func(_ context.Context) {
+					runningCh <- "running"
+				}
+			},
+			want:    "running",
+			wantErr: false,
+			errMsg:  "",
+		},
+		{
+			name: "execute run start server failure",
+			setup: func() {
+
+				t.Setenv(common.EnvIsLeaderElectionEnabled, "false")
+				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
+					return &k8sutils.K8sUtils{
+						KubernetesClient: k8sutils.KubernetesClient{
+							Clientset: fake.NewSimpleClientset(),
+						},
+					}, nil
+				}
+				startServerFunc = func(k8sUtils k8sutils.UtilsInterface, opts ServerOpts) (*Server, error) {
+					runningCh <- "should not be running"
+					return nil, errors.New("error, start server failed")
+				}
+			},
+			want:    "should not be running",
+			wantErr: true,
+			errMsg:  "error, start server failed",
+		},
+		{
+			name: "execute run k8s init failure",
+			setup: func() {
+
+				t.Setenv(common.EnvIsLeaderElectionEnabled, "false")
+				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
+					return nil, errors.New("error, k8s init failed")
+				}
+			},
+			want:    "",
+			wantErr: true,
+			errMsg:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer afterEach()
+
+			tt.setup()
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+			defer cancel()
+
+			errCh := make(chan error)
+			go func() {
+				errCh <- run(ctx)
+			}()
+
+			select {
+			case running := <-runningCh:
+				if running != tt.want {
+					t.Errorf("Run() = %v, want %v", running, tt.want)
+				}
+			case e := <-errCh:
+				if (e != nil) != tt.wantErr {
+					t.Errorf("Run() error = %v, wantErr %v", e, tt.wantErr)
+				}
+			case <-ctx.Done():
+				t.Errorf("Run() timed out")
+			}
+		})
+	}
+}
+
+func TestUpdateRevProxyLogParams(t *testing.T) {
+	tests := []struct {
+		name      string
+		format    string
+		logLevel  string
+		expectLog log.Level
+	}{
+		{"Default values", "", "", log.DebugLevel},
+		{"Valid JSON format", "json", "info", log.InfoLevel},
+		{"Valid Text format", "text", "warn", log.WarnLevel},
+		{"Invalid format defaults to text", "xml", "error", log.ErrorLevel},
+		{"Invalid log level defaults to debug", "json", "invalid", log.DebugLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture log output
+			var logOutput strings.Builder
+			logrus.SetOutput(&logOutput)
+
+			updateRevProxyLogParams(tt.format, tt.logLevel)
+
+			// Validate log level
+			assert.Equal(t, tt.expectLog, logrus.GetLevel())
+		})
+	}
+}
+
+func TestK8sInitFunc(t *testing.T) {
+	tests := []struct {
+		name        string
+		kubeClient  *k8sutils.KubernetesClient
+		expectError bool
+		expectNil   bool
+	}{
+		{
+			name: "Successful Initialization",
+			kubeClient: &k8sutils.KubernetesClient{
+				Clientset:         fake.NewSimpleClientset(),
+				RestForConfigFunc: func() (*rest.Config, error) { return &rest.Config{}, nil },
+				NewForConfigFunc: func(config *rest.Config) (kubernetes.Interface, error) {
+					return fake.NewSimpleClientset(), nil
+				},
+				GetPathFromEnvFunc: func() string { return "./" },
+			},
+			expectError: false,
+			expectNil:   false,
+		},
+		{
+			name: "Failed Initialization",
+			kubeClient: &k8sutils.KubernetesClient{
+				Clientset:         fake.NewSimpleClientset(),
+				RestForConfigFunc: func() (*rest.Config, error) { return &rest.Config{}, nil },
+				NewForConfigFunc: func(config *rest.Config) (kubernetes.Interface, error) {
+					return nil, errors.New("error")
+				},
+				GetPathFromEnvFunc: func() string { return "./" },
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resyncPeriod := 10 * time.Second
+			k8sUtils, err := k8sInitFunc("default", "/tmp/certs", true, resyncPeriod, tt.kubeClient)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.expectNil {
+				assert.Nil(t, k8sUtils)
+			} else {
+				assert.NotNil(t, k8sUtils)
+			}
+		})
+	}
+}
+
+func TestStartServerFuncFailure(t *testing.T) {
+	opts := getServerOpts()
+	//Invalid config file
+	opts.ConfigFileName = "invalid.yaml"
+	opts.ConfigDir = "./invalid-dir"
+	_, err := startServerFunc(k8smock.Init(), opts)
+	if err == nil {
+		t.Errorf("expecting server to not start, but it was started")
+	}
 }

--- a/csireverseproxy/manifests/revproxy.yaml
+++ b/csireverseproxy/manifests/revproxy.yaml
@@ -74,7 +74,7 @@ spec:
               value: /app/tls
               # Change this to the namespace where proxy will be installed
             - name: X_CSI_REVPROXY_WATCH_NAMESPACE
-              value: powermax         
+              value: powermax
           volumeMounts:
             - name: configmap-volume
               mountPath: /etc/config/configmap

--- a/csireverseproxy/manifests/revproxy.yaml
+++ b/csireverseproxy/manifests/revproxy.yaml
@@ -92,3 +92,4 @@ spec:
             secretName: csirevproxy-tls-secret
         - name: cert-dir
           emptyDir:
+          

--- a/csireverseproxy/manifests/revproxy.yaml
+++ b/csireverseproxy/manifests/revproxy.yaml
@@ -72,8 +72,9 @@ spec:
               value: "true"
             - name: X_CSI_REVPROXY_TLS_CERT_DIR
               value: /app/tls
+              # Change this to the namespace where proxy will be installed
             - name: X_CSI_REVPROXY_WATCH_NAMESPACE
-              value: powermax # Change this to the namespace where proxy will be installed
+              value: powermax         
           volumeMounts:
             - name: configmap-volume
               mountPath: /etc/config/configmap

--- a/csireverseproxy/manifests/revproxy.yaml
+++ b/csireverseproxy/manifests/revproxy.yaml
@@ -92,4 +92,3 @@ spec:
             secretName: csirevproxy-tls-secret
         - name: cert-dir
           emptyDir:
-          

--- a/csireverseproxy/pkg/config/config_test.go
+++ b/csireverseproxy/pkg/config/config_test.go
@@ -54,10 +54,6 @@ func TestReadConfig(t *testing.T) {
 	fmt.Printf("%v", proxyConfigMap)
 }
 
-// func newProxyConfig(configMap *ProxyConfigMap, utils k8sutils.UtilsInterface) (*ProxyConfig, error) {
-// 	return NewProxyConfig(configMap, utils)
-// }
-
 func getProxyConfig(t *testing.T) (*ProxyConfig, error) {
 	k8sUtils := k8smock.Init()
 	configMap, err := readConfig()

--- a/csireverseproxy/pkg/config/config_test.go
+++ b/csireverseproxy/pkg/config/config_test.go
@@ -16,15 +16,16 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"testing"
 
 	"revproxy/v2/pkg/common"
 	"revproxy/v2/pkg/k8smock"
-	"revproxy/v2/pkg/k8sutils"
 	"revproxy/v2/pkg/utils"
 
 	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 func readConfig() (*ProxyConfigMap, error) {
@@ -53,9 +54,9 @@ func TestReadConfig(t *testing.T) {
 	fmt.Printf("%v", proxyConfigMap)
 }
 
-func newProxyConfig(configMap *ProxyConfigMap, utils k8sutils.UtilsInterface) (*ProxyConfig, error) {
-	return NewProxyConfig(configMap, utils)
-}
+// func newProxyConfig(configMap *ProxyConfigMap, utils k8sutils.UtilsInterface) (*ProxyConfig, error) {
+// 	return NewProxyConfig(configMap, utils)
+// }
 
 func getProxyConfig(t *testing.T) (*ProxyConfig, error) {
 	k8sUtils := k8smock.Init()
@@ -107,12 +108,95 @@ func TestNewProxyConfig(t *testing.T) {
 	fmt.Println("Proxy config created successfully")
 }
 
+func TestParseConfig(t *testing.T) {
+	k8sUtils := k8smock.Init()
+	configMap, err := readConfig()
+	if err != nil {
+		t.Errorf("Failed to read config. (%s)", err.Error())
+		return
+	}
+
+	// deep copy the configmap to avoid modifying the original
+	deepCopyFunc := func(src *ProxyConfigMap) ProxyConfigMap {
+		var dst ProxyConfigMap
+		bytes, _ := yaml.Marshal(src)   // Serialize
+		_ = yaml.Unmarshal(bytes, &dst) // Deserialize
+		return dst
+	}
+
+	tests := []struct {
+		name    string
+		cm      ProxyConfigMap
+		before  func(*ProxyConfigMap)
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "ProxyConfigMap.Config is nil",
+			before: func(cm *ProxyConfigMap) {
+				*cm = deepCopyFunc(configMap)
+				cm.Config = nil
+			},
+			wantErr: true,
+		},
+		{
+			name: "Primary URL is nil",
+			before: func(cm *ProxyConfigMap) {
+				*cm = deepCopyFunc(configMap)
+				cm.Config.StorageArrayConfig[0].PrimaryURL = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "Backup URL is nil",
+			before: func(cm *ProxyConfigMap) {
+				*cm = deepCopyFunc(configMap)
+				cm.Config.StorageArrayConfig[0].BackupURL = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "Backup URL is not present",
+			before: func(cm *ProxyConfigMap) {
+				*cm = deepCopyFunc(configMap)
+				// modify the configmap to include a new array
+				cm.Config.StorageArrayConfig[0].BackupURL = "123000123000"
+			},
+			wantErr: true,
+		},
+		{
+			name: "Primary and backup URL non empty not present",
+			before: func(cm *ProxyConfigMap) {
+				*cm = deepCopyFunc(configMap)
+				storageArrayConfig := StorageArrayConfig{
+					PrimaryURL:             "new-primary-1.unisphe.re:8443",
+					BackupURL:              "new-backup-1.unisphe.re:8443",
+					StorageArrayID:         "123000123000",
+					ProxyCredentialSecrets: []string{"new-primary-unisphere-secret-1", "new-backup-unisphere-secret-1"},
+				}
+				cm.Config.StorageArrayConfig = append(cm.Config.StorageArrayConfig, storageArrayConfig)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.before(&tt.cm)
+			_, err = NewProxyConfig(&tt.cm, k8sUtils)
+			if err == nil && tt.wantErr {
+				t.Logf("Expecing error but got none")
+			}
+		})
+	}
+}
+
 func TestProxyConfig_UpdateCerts(t *testing.T) {
 	config, err := getProxyConfig(t)
 	if err != nil {
 		return
 	}
-	testSecrets := []string{"secret-cert", "invalid-secret-cert"}
+	testSecrets := []string{"secret-cert", "invalid-secret-cert", "primary-unisphere-secret-1", "primary-unisphere-secret-2"}
 	for _, secret := range testSecrets {
 		if config.IsSecretConfiguredForCerts(secret) {
 			config.UpdateCerts(secret, "/path/to/new/dummy/cert/file.pem")
@@ -126,7 +210,7 @@ func TestProxyConfig_UpdateCreds(t *testing.T) {
 	if err != nil {
 		return
 	}
-	testSecrets := []string{"proxy-secret", "powermax-secret"}
+	testSecrets := []string{"proxy-secret", "powermax-secret", "primary-unisphere-secret-1"}
 	newCredentials := &common.Credentials{
 		UserName: "new-test-username",
 		Password: "new-test-password",
@@ -154,6 +238,13 @@ func TestProxyConfig_UpdateCertsAndCredentials(t *testing.T) {
 	config.UpdateCertsAndCredentials(k8sUtils, serverSecret)
 	config.UpdateCertsAndCredentials(k8sUtils, proxySecret)
 	config.UpdateCertsAndCredentials(k8sUtils, certSecret)
+
+	primaryUnisphereSecret2, _ := k8sUtils.CreateNewCredentialSecret("primary-unisphere-secret-2")
+	primaryUnisphereSecret2.Data["username"] = []byte("new-username")
+	primaryUnisphereCert2, _ := k8sUtils.CreateNewCertSecret("primary-unisphere-cert-2")
+	config.UpdateCertsAndCredentials(k8sUtils, primaryUnisphereSecret2)
+	config.UpdateCertsAndCredentials(k8sUtils, primaryUnisphereCert2)
+
 	fmt.Println("Certs and Secrets updated successfully")
 }
 
@@ -169,6 +260,14 @@ func TestProxyConfig_UpdateManagementServers(t *testing.T) {
 		return
 	}
 	fmt.Println("Management servers updated successfully")
+
+	// Test for invalid DeepCopy
+	var nilConfig *ProxyConfig
+	returnedConfig := nilConfig.DeepCopy()
+	if returnedConfig != nil {
+		t.Errorf("Expected nil config")
+		return
+	}
 }
 
 func TestProxyConfig_UpdateManagedArrays(t *testing.T) {
@@ -178,6 +277,19 @@ func TestProxyConfig_UpdateManagedArrays(t *testing.T) {
 	}
 	newConfig := config.DeepCopy()
 	config.UpdateManagedArrays(newConfig)
+	fmt.Printf("Managed arrays updated successfully")
+
+	// Test invalid config
+	managedArrays := &newConfig.managedArrays
+	for _, array := range *managedArrays {
+		saveURL := array.PrimaryURL
+		array.PrimaryURL = url.URL{
+			Scheme: "https", Host: "new-primary-1.unisphe.re:8443"}
+		config.UpdateManagedArrays(newConfig)
+		array.PrimaryURL = saveURL
+
+	}
+	//config.UpdateManagedArrays(newConfig)
 	fmt.Printf("Managed arrays updated successfully")
 }
 
@@ -194,5 +306,62 @@ func TestProxyConfig_GetStorageArray(t *testing.T) {
 	if err != nil {
 		return
 	}
-	fmt.Printf("Storage arrays: %+v\n", config.GetStorageArray("000197900045"))
+	fmt.Printf("Storage arrays: %+v\n", config.GetStorageArray("000197900045")) //non empty invalid
+	fmt.Printf("Storage arrays: %+v\n", config.GetStorageArray("000000000001")) // non empty valid
+	fmt.Printf("Storage arrays: %+v\n", config.GetStorageArray(""))             //emp
+
+}
+
+func TestProxyConfig_GetManagedArrayAndServers(t *testing.T) {
+	config, err := getProxyConfig(t)
+	if err != nil {
+		return
+	}
+
+	_ = config.GetManagedArraysAndServers()
+}
+
+func Test_GetManagementServerCredentials(t *testing.T) {
+	config, err := getProxyConfig(t)
+	if err != nil {
+		return
+	}
+
+	for _, server := range config.GetManagementServers() {
+		_, _ = config.GetManagementServerCredentials(server.URL)
+	}
+
+	// Fetch invalid mgmt server
+	_, _ = config.GetManagementServerCredentials(url.URL{
+		Scheme: "https",
+		Host:   "10.20.30.40",
+	})
+}
+
+func TestGetManagementServer(t *testing.T) {
+	config, err := getProxyConfig(t)
+	if err != nil {
+		return
+	}
+	for _, server := range config.GetManagementServers() {
+		_, _ = config.GetManagementServer(server.URL)
+	}
+
+	_, _ = config.GetManagementServer(url.URL{
+		Scheme: "https",
+		Host:   "10.20.30.40",
+	})
+}
+
+func TestIsUserAuthorized(t *testing.T) {
+	config, err := getProxyConfig(t)
+	if err != nil {
+		return
+	}
+
+	// valiid username, nonexistent array
+	_, _ = config.IsUserAuthorized("test-username", "test-password", "12345678910")
+
+	// nonexistent username
+	_, _ = config.IsUserAuthorized("non-existent-username", "test-password", "12345678910")
 }

--- a/csireverseproxy/pkg/k8smock/k8smock.go
+++ b/csireverseproxy/pkg/k8smock/k8smock.go
@@ -156,8 +156,7 @@ func (mockUtils *MockUtils) GetCredentialsFromSecret(secret *corev1.Secret) (*co
 }
 
 // StartInformer - mock implementation for StartInformer
-func (mockUtils *MockUtils) StartInformer(callback func(k8sutils.UtilsInterface, *corev1.Secret)) error {
-	return nil
+func (mockUtils *MockUtils) StartInformer(callback func(k8sutils.UtilsInterface, *corev1.Secret)) {
 }
 
 // StopInformer - mock implementation for StopInformer

--- a/csireverseproxy/pkg/k8smock/k8smock_test.go
+++ b/csireverseproxy/pkg/k8smock/k8smock_test.go
@@ -52,12 +52,7 @@ func TestStartInformer(t *testing.T) {
 	dummyEventHandler := func(ui k8sutils.UtilsInterface, secret *corev1.Secret) {}
 
 	mockUtils := Init()
-	err := mockUtils.StartInformer(dummyEventHandler)
-	if err != nil {
-		t.Errorf("Failed to start informer: %v", err)
-		return
-	}
-
+	mockUtils.StartInformer(dummyEventHandler)
 	fmt.Printf("mockUtils: %+v\n", mockUtils)
 }
 

--- a/csireverseproxy/pkg/k8sutils/k8sutils.go
+++ b/csireverseproxy/pkg/k8sutils/k8sutils.go
@@ -41,7 +41,7 @@ type UtilsInterface interface {
 	GetCertFileFromSecretName(string) (string, error)
 	GetCredentialsFromSecret(*corev1.Secret) (*common.Credentials, error)
 	GetCredentialsFromSecretName(string) (*common.Credentials, error)
-	StartInformer(func(UtilsInterface, *corev1.Secret)) error
+	StartInformer(func(UtilsInterface, *corev1.Secret))
 	StopInformer()
 }
 
@@ -241,7 +241,7 @@ func (utils *K8sUtils) createFile(fileName string, data []byte) error {
 
 // StartInformer -  starts the informer to listen for any events related to secrets
 // in the namespace being watched
-func (utils *K8sUtils) StartInformer(callback func(UtilsInterface, *corev1.Secret)) error {
+func (utils *K8sUtils) StartInformer(callback func(UtilsInterface, *corev1.Secret)) {
 	utils.SecretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			callback(utils, obj.(*corev1.Secret))
@@ -257,7 +257,6 @@ func (utils *K8sUtils) StartInformer(callback func(UtilsInterface, *corev1.Secre
 	}) // #nosec G104
 
 	utils.InformerFactory.Start(utils.stopCh)
-	return nil
 }
 
 // StopInformer - stops the informer

--- a/csireverseproxy/pkg/k8sutils/k8sutils_test.go
+++ b/csireverseproxy/pkg/k8sutils/k8sutils_test.go
@@ -573,10 +573,7 @@ func TestStartInformer(t *testing.T) {
 
 	// Start the informer in a separate goroutine
 	go func() {
-		err := utils.StartInformer(callback)
-		if err != nil {
-			t.Errorf("StartInformer failed: %v", err)
-		}
+		utils.StartInformer(callback)
 	}()
 
 	// Wait for informer to start

--- a/csireverseproxy/test-config/config.yaml
+++ b/csireverseproxy/test-config/config.yaml
@@ -1,4 +1,6 @@
 port: 2222
+logLevel: info
+logFormat: text
 config:
   storageArrays:
     - storageArrayId: "000000000001"
@@ -19,10 +21,12 @@ config:
       skipCertificateValidation: true
     - url: https://backup-1.unisphe.re:8443
       arrayCredentialSecret: backup-unisphere-secret-1
-      skipCertificateValidation: false
+      skipCertificateValidation: true
     - url: https://primary-2.unisphe.re:8443
       arrayCredentialSecret: primary-unisphere-secret-2
-      skipCertificateValidation: true
+      skipCertificateValidation: false
+      certSecret: primary-unisphere-cert-2
     - url: https://backup-2.unisphe.re:8443
       arrayCredentialSecret: backup-unisphere-secret-2
       skipCertificateValidation: false
+      certSecret: primary-unisphere-cert-2

--- a/csireverseproxy/test-config/config.yaml
+++ b/csireverseproxy/test-config/config.yaml
@@ -30,4 +30,3 @@ config:
       arrayCredentialSecret: backup-unisphere-secret-2
       skipCertificateValidation: false
       certSecret: primary-unisphere-cert-2
-      

--- a/csireverseproxy/test-config/config.yaml
+++ b/csireverseproxy/test-config/config.yaml
@@ -30,3 +30,4 @@ config:
       arrayCredentialSecret: backup-unisphere-secret-2
       skipCertificateValidation: false
       certSecret: primary-unisphere-cert-2
+      


### PR DESCRIPTION
# Description
Increase UT coverage for main and pkg/config in csireverseproxy. Note: This is not merge to MAIN but to usr/spark/unit-test-improvements branch.  

Note: 
1. unused functions ( a couple of DeepCopy) were removed. 
2. StartInformer signature modified, was not returning anything but nil 
3. Some structs were moved to the top of file for better readability. 
4. Methods in main.go main() and run() are now dependency injected to improve testability. 


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Unit test run: 
ok      revproxy/v2/pkg/config  0.995s  coverage: 90.9% of statements
ok  	revproxy/v2	3.616s	coverage: 90.3% of statements

cert-csi run with image built from this branch:

Tests:
--------------------------------------------------------------
1. TestCase: VolumeIoSuite
            Started:   2025-02-10 15:56:02.84276917 +0000 UTC
            Ended:     2025-02-10 16:05:33.366058413 +0000 UTC
            Result:    SUCCESS

            Stage metrics:
                    PVCAttachment:
                        Avg: 9.150266055s
                        Min: 6.068738574s
                        Max: 10.400494338s
                        Histogram:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PVCAttachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PVCAttachment_boxplot.png
                    PVCBind:
                        Avg: 5.212699664s
                        Min: 4.432488s
                        Max: 6.871985705s
                        Histogram:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PVCBind.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PVCBind_boxplot.png
                    PVCCreation:
                        Avg: 14.982617498s
                        Min: 13.90772687s
                        Max: 15.439022831s
                        Histogram:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PVCCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PVCCreation_boxplot.png
                    PVCDeletion:
                        Avg: 38.87106ms
                        Min: 21.435327ms
                        Max: 53.284679ms
                        Histogram:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PVCDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PVCDeletion_boxplot.png
                    PVCUnattachment:
                        Avg: 1.986117825s
                        Min: 1.854954413s
                        Max: 2.392359051s
                        Histogram:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PVCUnattachment.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PVCUnattachment_boxplot.png
                    PodCreation:
                        Avg: 1m0.533543652s
                        Min: 29.907716147s
                        Max: 1m45.918245458s
                        Histogram:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PodCreation.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PodCreation_boxplot.png
                    PodDeletion:
                        Avg: 12.855521834s
                        Min: 7.982860897s
                        Max: 21.208691894s
                        Histogram:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PodDeletion.png
                        BoxPlot:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/PodDeletion_boxplot.png
                        EntityNumberOverTime:
        /root/.cert-csi/reports/test-run-a888432c/VolumeIoSuite7/EntityNumberOverTime.png

[2025-02-10 16:05:33]  INFO Avg time of a run:   554.23s
[2025-02-10 16:05:33]  INFO Avg time of a del:   12.01s
[2025-02-10 16:05:33]  INFO Avg time of all:     570.52s
[2025-02-10 16:05:33]  INFO During this run 100.0% of suites succeeded
