### PR TITLE
Add Proxy Package Tests for ReverseProxy

### DIFF
--- a/csireverseproxy/pkg/proxy/proxy.go
+++ b/csireverseproxy/pkg/proxy/proxy.go
@@ -535,11 +535,15 @@ func (revProxy *Proxy) ServeVolumePerformance(res http.ResponseWriter, req *http
 	decoder := json.NewDecoder(req.Body)
 	if err := decoder.Decode(reqParam); err != nil {
 		log.Errorf("Decoding fails for mertics req for volume: %s", err.Error())
+		return
 	}
+
 	resp, err := revProxy.getResponseIfAuthorised(res, req, reqParam.SystemID)
 	if err != nil {
 		log.Errorf("Authorisation step fails for: (%s) symID with error (%s)", reqParam.SystemID, err.Error())
+		return
 	}
+
 	defer resp.Body.Close()
 	err = utils.IsValidResponse(resp)
 	if err != nil {

--- a/csireverseproxy/pkg/proxy/proxy.go
+++ b/csireverseproxy/pkg/proxy/proxy.go
@@ -564,11 +564,15 @@ func (revProxy *Proxy) ServeFSPerformance(res http.ResponseWriter, req *http.Req
 	decoder := json.NewDecoder(req.Body)
 	if err := decoder.Decode(reqParam); err != nil {
 		log.Errorf("Decoding fails for mertics req for volume: %s", err.Error())
+		return
 	}
+
 	resp, err := revProxy.getResponseIfAuthorised(res, req, reqParam.SystemID)
 	if err != nil {
 		log.Errorf("Authorisation step fails for: (%s) symID with error (%s)", reqParam.SystemID, err.Error())
+		return
 	}
+
 	defer resp.Body.Close()
 	err = utils.IsValidResponse(resp)
 	if err != nil {

--- a/csireverseproxy/pkg/proxy/proxy_test.go
+++ b/csireverseproxy/pkg/proxy/proxy_test.go
@@ -254,6 +254,41 @@ func TestGetRouter_ServeVolume(t *testing.T) {
 			})),
 		},
 		{
+			name: "Success: ServeVolume - with symid header",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("/univmax/restapi/%s/sloprovisioning/symmetrix/%s/volume", "9.1", arrayID)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+					req.Header.Set("symid", arrayID)
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+
+			})),
+		},
+		{
 			name: "Fail: ServeVolume - unauthorized",
 			proxy: func(server *httptest.Server) *Proxy {
 				// Create a new Proxy
@@ -446,6 +481,31 @@ func TestGetRouter_ServeReverseProxy(t *testing.T) {
 
 			})),
 		},
+		{
+			name: "Fail: ServeReverseProxy - unauthorized",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix/%s", utils.Prefix, "9.1", arrayID)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{}
+					req = mux.SetURLVars(req, vars)
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})),
+		},
 	}
 
 	utils.InitializeLock()
@@ -499,6 +559,39 @@ func TestGetRouter_ServeVersions(t *testing.T) {
 					}
 					req = mux.SetURLVars(req, vars)
 					req.SetBasicAuth("test-username", "test-password")
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+
+			})),
+		},
+		{
+			name: "Success: ServeVersions - with symid in header",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/%s/system/version", utils.Prefix, "9.1")
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+					req.Header.Set("symid", arrayID)
 					return req
 				},
 			},
@@ -586,6 +679,304 @@ func TestGetRouter_ServeVersions(t *testing.T) {
 	}
 }
 
+func TestGetRouter_ServePerformance(t *testing.T) {
+	testCases := []struct {
+		name   string
+		proxy  func(*httptest.Server) *Proxy
+		req    []func() *http.Request
+		server *httptest.Server
+	}{
+		{
+			name: "Success: ServePerformance - /performance/Array/keys",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/performance/Array/keys", utils.Prefix)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+
+			})),
+		},
+		{
+			name: "Fail: ServeVersions - unauthorized",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/performance/Array/keys", utils.Prefix)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})),
+		},
+	}
+
+	utils.InitializeLock()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := tc.proxy(tc.server)
+			if proxy == nil {
+				return
+			}
+
+			// Setup router
+			router := proxy.GetRouter()
+			for _, reqFunc := range tc.req {
+				req := reqFunc()
+				router.ServeHTTP(httptest.NewRecorder(), req)
+			}
+		})
+	}
+}
+
+func TestGetRouter_ServeVolumePerformance(t *testing.T) {
+	testCases := []struct {
+		name   string
+		proxy  func(*httptest.Server) *Proxy
+		req    []func() *http.Request
+		server *httptest.Server
+	}{
+		{
+			name: "Success: ServeVolumePerformance - /performance/Volume/metrics",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/performance/Volume/metrics", utils.Prefix)
+
+					body := []byte(`{"systemId": "000000000001"}`)
+					req, _ := http.NewRequest("GET", url, bytes.NewBuffer(body))
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+
+			})),
+		},
+		{
+			name: "Fail: ServeVolumePerformance - Empty Body",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/performance/Volume/metrics", utils.Prefix)
+
+					body := []byte(``)
+					req, _ := http.NewRequest("GET", url, bytes.NewBuffer(body))
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+
+			})),
+		},
+		{
+			name: "Fail: ServeVolumePerformance - Invalid SystemID",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/performance/Volume/metrics", utils.Prefix)
+
+					// Invalid systemID
+					body := []byte(`{"systemId": "000000000009"}`)
+					req, _ := http.NewRequest("GET", url, bytes.NewBuffer(body))
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+
+			})),
+		},
+		{
+			name: "Fail: ServeVolumePerformance - Bad Response",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/performance/Volume/metrics", utils.Prefix)
+
+					body := []byte(`{"systemId": "000000000001"}`)
+					req, _ := http.NewRequest("GET", url, bytes.NewBuffer(body))
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			})),
+		},
+		{
+			name: "Fail: ServeVolumePerformance - Empty Response",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/performance/Volume/metrics", utils.Prefix)
+
+					body := []byte(`{"systemId": "000000000001"}`)
+					req, _ := http.NewRequest("GET", url, bytes.NewBuffer(body))
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(``))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+			})),
+		},
+	}
+
+	utils.InitializeLock()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := tc.proxy(tc.server)
+			if proxy == nil {
+				return
+			}
+
+			// Setup router
+			router := proxy.GetRouter()
+			for _, reqFunc := range tc.req {
+				req := reqFunc()
+				router.ServeHTTP(httptest.NewRecorder(), req)
+			}
+		})
+	}
+}
+
 func TestGetRouter(t *testing.T) {
 	volumeIteratorID := "00000000-1111-2abc-def3-44gh55ij66kl_0"
 	server := fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -633,65 +1024,6 @@ func TestGetRouter(t *testing.T) {
 		req         []func() *http.Request
 		expectedErr error
 	}{
-		{
-			name: "Success: ServePerformance - /performance/Array/keys",
-			proxy: func() *Proxy {
-				// Create a new Proxy
-				proxy, err := createValidProxyConfig(t, server)
-				if err != nil {
-					t.Errorf("Failed to create proxy: %v", err)
-					return nil
-				}
-
-				return proxy
-			},
-			req: []func() *http.Request{
-				func() *http.Request {
-					arrayID := "000000000001"
-					url := fmt.Sprintf("%s/performance/Array/keys", utils.Prefix)
-					req, _ := http.NewRequest("GET", url, nil)
-
-					vars := map[string]string{
-						"symid": arrayID,
-					}
-					req = mux.SetURLVars(req, vars)
-					req.SetBasicAuth("test-username", "test-password")
-					return req
-				},
-			},
-			expectedErr: nil,
-		},
-		{
-			name: "Success: ServeVolumePerformance - /performance/Volume/metrics",
-			proxy: func() *Proxy {
-				// Create a new Proxy
-				proxy, err := createValidProxyConfig(t, server)
-				if err != nil {
-					t.Errorf("Failed to create proxy: %v", err)
-					return nil
-				}
-
-				return proxy
-			},
-			req: []func() *http.Request{
-				func() *http.Request {
-					arrayID := "000000000001"
-					url := fmt.Sprintf("%s/performance/Volume/metrics", utils.Prefix)
-
-					body := []byte(`{"systemId": "000000000001"}`)
-					req, _ := http.NewRequest("GET", url, bytes.NewBuffer(body))
-
-					vars := map[string]string{
-						"symid": arrayID,
-					}
-					req = mux.SetURLVars(req, vars)
-					req.SetBasicAuth("test-username", "test-password")
-
-					return req
-				},
-			},
-			expectedErr: nil,
-		},
 		{
 			name: "Success: ServeFSPerformance - /performance/file/filesystem/metrics",
 			proxy: func() *Proxy {

--- a/csireverseproxy/pkg/proxy/proxy_test.go
+++ b/csireverseproxy/pkg/proxy/proxy_test.go
@@ -1336,6 +1336,217 @@ func TestGetRouter_ServeIterator(t *testing.T) {
 	}
 }
 
+func TestGetRouter_ServeSymmetrix(t *testing.T) {
+	testCases := []struct {
+		name   string
+		proxy  func(*httptest.Server) *Proxy
+		req    []func() *http.Request
+		server *httptest.Server
+	}{
+		{
+			name: "Success: ServeSymmetrix - /{version}/sloprovisioning/symmetrix",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					version := "1.0"
+					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix", utils.Prefix, version)
+
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				list := types.SymmetrixIDList{
+					SymmetrixIDs: []string{"00000000-1111-2abc-def3-44gh55ij66kl"},
+				}
+
+				bytes, _ := json.Marshal(list)
+
+				_, err := w.Write(bytes)
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+			})),
+		},
+		{
+			name: "Fail: ServeSymmetrix - unauthorized",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					version := "1.0"
+					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix", utils.Prefix, version)
+
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})),
+		},
+		{
+			name: "Fail: ServeSymmetrix - Bad Response",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					version := "1.0"
+					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix", utils.Prefix, version)
+
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			})),
+		},
+		{
+			name: "Fail: ServeSymmetrix - Illformed Response",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					version := "1.0"
+					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix", utils.Prefix, version)
+
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				bytes, _ := json.Marshal(``)
+
+				_, err := w.Write(bytes)
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+			})),
+		},
+		{
+			name: "Fail: ServeSymmetrix - Empty Response",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					version := "1.0"
+					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix", utils.Prefix, version)
+
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				list := types.SymmetrixIDList{}
+
+				bytes, _ := json.Marshal(list)
+
+				_, err := w.Write(bytes)
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+			})),
+		},
+	}
+
+	utils.InitializeLock()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := tc.proxy(tc.server)
+			if proxy == nil {
+				return
+			}
+
+			// Setup router
+			router := proxy.GetRouter()
+			for _, reqFunc := range tc.req {
+				req := reqFunc()
+				router.ServeHTTP(httptest.NewRecorder(), req)
+			}
+		})
+	}
+}
+
 func TestGetRouter(t *testing.T) {
 	// volumeIteratorID := "00000000-1111-2abc-def3-44gh55ij66kl_0"
 	server := fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1383,37 +1594,6 @@ func TestGetRouter(t *testing.T) {
 		req         []func() *http.Request
 		expectedErr error
 	}{
-		{
-			name: "Success: ServeSymmetrix - /{version}/sloprovisioning/symmetrix",
-			proxy: func() *Proxy {
-				// Create a new Proxy
-				proxy, err := createValidProxyConfig(t, server)
-				if err != nil {
-					t.Errorf("Failed to create proxy: %v", err)
-					return nil
-				}
-
-				return proxy
-			},
-			req: []func() *http.Request{
-				func() *http.Request {
-					arrayID := "000000000001"
-					version := "1.0"
-					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix", utils.Prefix, version)
-
-					req, _ := http.NewRequest("GET", url, nil)
-
-					vars := map[string]string{
-						"symid": arrayID,
-					}
-					req = mux.SetURLVars(req, vars)
-					req.SetBasicAuth("test-username", "test-password")
-
-					return req
-				},
-			},
-			expectedErr: nil,
-		},
 		{
 			name: "Success: ServeReplicationCapabilities - /{version}/replication/capabilities/symmetrix",
 			proxy: func() *Proxy {

--- a/csireverseproxy/pkg/proxy/proxy_test.go
+++ b/csireverseproxy/pkg/proxy/proxy_test.go
@@ -22,7 +22,6 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"revproxy/v2/pkg/common"
 	"revproxy/v2/pkg/config"
@@ -213,6 +212,198 @@ func TestUpdateConfig(t *testing.T) {
 	// End of Test No Update
 }
 
+func TestGetRouter_ServeVolume(t *testing.T) {
+	testCases := []struct {
+		name   string
+		proxy  func(*httptest.Server) *Proxy
+		req    []func() *http.Request
+		server *httptest.Server
+	}{
+		{
+			name: "Success: ServeVolume - /{version}/sloprovisioning/symmetrix/{symid}/volume",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("/univmax/restapi/%s/sloprovisioning/symmetrix/%s/volume", "9.1", arrayID)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+
+			})),
+		},
+		{
+			name: "Fail: ServeVolume - unauthorized",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("/univmax/restapi/%s/sloprovisioning/symmetrix/%s/volume", "9.1", arrayID)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+
+			})),
+		},
+		{
+			name: "Fail: ServeVolume - unauthorized - wrong password",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("/univmax/restapi/%s/sloprovisioning/symmetrix/%s/volume", "9.1", arrayID)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "myPassword")
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+			})),
+		},
+		{
+			name: "Fail: ServeVolume - Bad Response",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("/univmax/restapi/%s/sloprovisioning/symmetrix/%s/volume", "9.1", arrayID)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			})),
+		},
+		{
+			name: "Fail: ServeVolume - Empty Response",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("/univmax/restapi/%s/sloprovisioning/symmetrix/%s/volume", "9.1", arrayID)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(``))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+			})),
+		},
+	}
+
+	utils.InitializeLock()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := tc.proxy(tc.server)
+			if proxy == nil {
+				return
+			}
+
+			// Setup router
+			router := proxy.GetRouter()
+			for _, reqFunc := range tc.req {
+				req := reqFunc()
+				router.ServeHTTP(httptest.NewRecorder(), req)
+			}
+
+			t.Logf("Router: %v", router)
+		})
+	}
+}
 func TestGetRouter(t *testing.T) {
 	volumeIteratorID := "00000000-1111-2abc-def3-44gh55ij66kl_0"
 	server := fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -261,34 +452,6 @@ func TestGetRouter(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			name: "Success: ServeVolume - /{version}/sloprovisioning/symmetrix/{symid}/volume",
-			proxy: func() *Proxy {
-				// Create a new Proxy
-				proxy, err := createValidProxyConfig(t, server)
-				if err != nil {
-					t.Errorf("Failed to create proxy: %v", err)
-					return nil
-				}
-
-				return proxy
-			},
-			req: []func() *http.Request{
-				func() *http.Request {
-					arrayID := "000000000001"
-					url := fmt.Sprintf("/univmax/restapi/%s/sloprovisioning/symmetrix/%s/volume", "9.1", arrayID)
-					req, _ := http.NewRequest("GET", url, nil)
-
-					vars := map[string]string{
-						"symid": arrayID,
-					}
-					req = mux.SetURLVars(req, vars)
-					req.SetBasicAuth("test-username", "test-password")
-					return req
-				},
-			},
-			expectedErr: nil,
-		},
-		{
 			name: "Success: ServeReverseProxy - /{version}/sloprovisioning/symmetrix/{symid}",
 			proxy: func() *Proxy {
 				// Create a new Proxy
@@ -311,6 +474,33 @@ func TestGetRouter(t *testing.T) {
 					}
 					req = mux.SetURLVars(req, vars)
 					req.SetBasicAuth("test-username", "test-password")
+					return req
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "Fail: ServeReverseProxy - unauthorized",
+			proxy: func() *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix/%s", utils.Prefix, "9.1", arrayID)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
 					return req
 				},
 			},
@@ -543,8 +733,9 @@ func TestGetRouter(t *testing.T) {
 		},
 	}
 
-	go utils.LockRequestHandler()
-	time.Sleep(100 * time.Millisecond) // Allow goroutine to start
+	// go utils.LockRequestHandler()
+	// time.Sleep(100 * time.Millisecond) // Allow goroutine to start
+	utils.InitializeLock()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/csireverseproxy/pkg/proxy/proxy_test.go
+++ b/csireverseproxy/pkg/proxy/proxy_test.go
@@ -468,6 +468,124 @@ func TestGetRouter_ServeReverseProxy(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRouter_ServeVersions(t *testing.T) {
+	testCases := []struct {
+		name   string
+		proxy  func(*httptest.Server) *Proxy
+		req    []func() *http.Request
+		server *httptest.Server
+	}{
+		{
+			name: "Success: ServeVersions - /{version}/system/version",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/%s/system/version", utils.Prefix, "9.1")
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+
+			})),
+		},
+		{
+			name: "Fail: ServeVersions - unauthorized",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/%s/system/version", utils.Prefix, "9.1")
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})),
+		},
+		{
+			name: "Fail: ServeVersions - unauthorized - wrong password",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/%s/system/version", utils.Prefix, "9.1")
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "myPassword")
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})),
+		},
+	}
+
+	utils.InitializeLock()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := tc.proxy(tc.server)
+			if proxy == nil {
+				return
+			}
+
+			// Setup router
+			router := proxy.GetRouter()
+			for _, reqFunc := range tc.req {
+				req := reqFunc()
+				router.ServeHTTP(httptest.NewRecorder(), req)
+			}
+		})
+	}
+}
+
 func TestGetRouter(t *testing.T) {
 	volumeIteratorID := "00000000-1111-2abc-def3-44gh55ij66kl_0"
 	server := fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -515,34 +633,6 @@ func TestGetRouter(t *testing.T) {
 		req         []func() *http.Request
 		expectedErr error
 	}{
-		{
-			name: "Success: ServeVersions - /{version}/system/version",
-			proxy: func() *Proxy {
-				// Create a new Proxy
-				proxy, err := createValidProxyConfig(t, server)
-				if err != nil {
-					t.Errorf("Failed to create proxy: %v", err)
-					return nil
-				}
-
-				return proxy
-			},
-			req: []func() *http.Request{
-				func() *http.Request {
-					arrayID := "000000000001"
-					url := fmt.Sprintf("%s/%s/system/version", utils.Prefix, "9.1")
-					req, _ := http.NewRequest("GET", url, nil)
-
-					vars := map[string]string{
-						"symid": arrayID,
-					}
-					req = mux.SetURLVars(req, vars)
-					req.SetBasicAuth("test-username", "test-password")
-					return req
-				},
-			},
-			expectedErr: nil,
-		},
 		{
 			name: "Success: ServePerformance - /performance/Array/keys",
 			proxy: func() *Proxy {

--- a/csireverseproxy/pkg/proxy/proxy_test.go
+++ b/csireverseproxy/pkg/proxy/proxy_test.go
@@ -1,0 +1,262 @@
+/*
+ Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"revproxy/v2/pkg/common"
+	"revproxy/v2/pkg/config"
+	"revproxy/v2/pkg/k8smock"
+	"revproxy/v2/pkg/utils"
+
+	"github.com/gorilla/mux"
+)
+
+func readConfigFile() string {
+	relativePath := filepath.Join(".", "..", "..", common.TestConfigDir, common.TestConfigFileName)
+	return relativePath
+}
+
+func TestNewProxy(t *testing.T) {
+	configFile := readConfigFile()
+	configMap, err := config.ReadConfig(filepath.Base(configFile), filepath.Dir(configFile))
+	if err != nil {
+		t.Fatalf("Failed to read config: %v", err)
+	}
+
+	k8sUtils := k8smock.Init()
+	_, err = k8sUtils.CreateNewCertSecret("secret-cert")
+	if err != nil {
+		t.Fatalf("Failed to create new cert secret: %v", err)
+	}
+
+	err = createSecrets(k8sUtils)
+	if err != nil {
+		t.Fatalf("Failed to create secrets: %v", err)
+	}
+
+	proxyConfig, err := config.NewProxyConfig(configMap, k8sUtils)
+	if err != nil {
+		t.Fatalf("Failed to create new proxy config: %v", err)
+	}
+
+	t.Logf("proxyConfig: %v", proxyConfig)
+
+	// Create a new Proxy using the ProxyConfig
+	_, err = NewProxy(*proxyConfig)
+	if err != nil {
+		t.Errorf("Failed to create new proxy: %v", err)
+		return
+	}
+}
+
+func TestGetRouter(t *testing.T) {
+	testCases := []struct {
+		name           string
+		proxy          *Proxy
+		expectedRouter *mux.Router
+		expectedErr    error
+	}{
+		{
+			name: "Successful case",
+			proxy: &Proxy{
+				config: config.ProxyConfig{
+					// Set the necessary fields for the ProxyConfig
+				},
+			},
+			expectedRouter: mux.NewRouter(),
+			expectedErr:    nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			router := tc.proxy.GetRouter()
+			req := func() *http.Request {
+				// ctx := context.WithValue(context.Background(), 0, arrayID)
+				req, _ := http.NewRequest("GET", "/volume", nil)
+				vars := map[string]string{
+					"symid": "000000000001",
+				}
+				req = mux.SetURLVars(req, vars)
+				req.SetBasicAuth("test-username", "test-password")
+				return req
+			}()
+
+			router.ServeHTTP(httptest.NewRecorder(), req)
+
+			t.Logf("Router: %v", router)
+		})
+	}
+}
+
+type ProxyClientSymIDKey string
+
+func TestServeVolume(t *testing.T) {
+	server := fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("fake unisphere received: %s %s", r.Method, r.URL)
+		_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+		if err != nil {
+			t.Errorf("expected nil error, got %v", err)
+		}
+	}))
+
+	// symKey := "proxyClientSymID"
+	arrayID := "000000000001"
+	testCases := []struct {
+		name        string
+		proxy       func() *Proxy
+		req         *http.Request
+		expectedErr error
+	}{
+		{
+			name: "Successful case",
+			proxy: func() *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: func() *http.Request {
+				// ctx := context.WithValue(context.Background(), 0, arrayID)
+				req, _ := http.NewRequest("GET", "/volume", nil)
+				vars := map[string]string{
+					"symid": arrayID,
+				}
+				req = mux.SetURLVars(req, vars)
+				req.SetBasicAuth("test-username", "test-password")
+				return req
+			}(),
+			expectedErr: nil,
+		},
+		// {
+		// 	name:  "Error case",
+		// 	proxy: &Proxy{
+		// 		// Set the necessary fields for the Proxy object
+		// 	},
+		// 	req: func() *http.Request {
+		// 		req, _ := http.NewRequest("GET", "/volume", nil)
+		// 		return req
+		// 	}(),
+		// 	expectedErr: errors.New("some error"),
+		// },
+		// Add more test cases as needed
+	}
+
+	go utils.LockRequestHandler()
+	time.Sleep(100 * time.Millisecond) // Allow goroutine to start
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := tc.proxy()
+			if proxy == nil {
+				return
+			}
+
+			proxy.ServeVolume(httptest.NewRecorder(), tc.req)
+			// if !reflect.DeepEqual(err, tc.expectedErr) {
+			// 	t.Errorf("Expected error to be %v, but got %v", tc.expectedErr, err)
+			// }
+		})
+	}
+}
+
+func createSecrets(k8sUtils *k8smock.MockUtils) error {
+	_, err := k8sUtils.CreateNewCredentialSecret("primary-unisphere-secret-1")
+	if err != nil {
+		return err
+	}
+
+	_, err = k8sUtils.CreateNewCredentialSecret("backup-unisphere-secret-1")
+	if err != nil {
+		return err
+	}
+
+	_, err = k8sUtils.CreateNewCredentialSecret("primary-unisphere-secret-2")
+	if err != nil {
+		return err
+	}
+
+	_, err = k8sUtils.CreateNewCredentialSecret("backup-unisphere-secret-2")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createValidProxyConfig(_ *testing.T, server *httptest.Server) (*Proxy, error) {
+	configMap := mockProxyConfigMap(server)
+
+	k8sUtils := k8smock.Init()
+	_, err := k8sUtils.CreateNewCertSecret("secret-cert")
+	if err != nil {
+		return nil, err
+	}
+
+	err = createSecrets(k8sUtils)
+	if err != nil {
+		return nil, err
+	}
+
+	proxyConfig, err := config.NewProxyConfig(configMap, k8sUtils)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy, err := NewProxy(*proxyConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return proxy, nil
+}
+
+func fakeServer(t *testing.T, h http.Handler) *httptest.Server {
+	s := httptest.NewServer(h)
+	t.Cleanup(func() {
+		s.Close()
+	})
+	return s
+}
+
+func mockProxyConfigMap(server *httptest.Server) *config.ProxyConfigMap {
+	return &config.ProxyConfigMap{
+		Port:      "2222",
+		LogLevel:  "info",
+		LogFormat: "json",
+		Config: &config.Config{
+			StorageArrayConfig: []config.StorageArrayConfig{
+				{
+					StorageArrayID:         "000000000001",
+					PrimaryURL:             server.URL,
+					ProxyCredentialSecrets: []string{"primary-unisphere-secret-1", "backup-unisphere-secret-1"},
+				},
+			},
+			ManagementServerConfig: []config.ManagementServerConfig{
+				{URL: server.URL, SkipCertificateValidation: true},
+			},
+		},
+	}
+}

--- a/csireverseproxy/pkg/proxy/proxy_test.go
+++ b/csireverseproxy/pkg/proxy/proxy_test.go
@@ -404,6 +404,70 @@ func TestGetRouter_ServeVolume(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRouter_ServeReverseProxy(t *testing.T) {
+	testCases := []struct {
+		name   string
+		proxy  func(*httptest.Server) *Proxy
+		req    []func() *http.Request
+		server *httptest.Server
+	}{
+		{
+			name: "Success: ServeReverseProxy - /{version}/sloprovisioning/symmetrix/{symid}",
+			proxy: func(server *httptest.Server) *Proxy {
+				// Create a new Proxy
+				proxy, err := createValidProxyConfig(t, server)
+				if err != nil {
+					t.Errorf("Failed to create proxy: %v", err)
+					return nil
+				}
+
+				return proxy
+			},
+			req: []func() *http.Request{
+				func() *http.Request {
+					arrayID := "000000000001"
+					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix/%s", utils.Prefix, "9.1", arrayID)
+					req, _ := http.NewRequest("GET", url, nil)
+
+					vars := map[string]string{
+						"symid": arrayID,
+					}
+					req = mux.SetURLVars(req, vars)
+					req.SetBasicAuth("test-username", "test-password")
+					return req
+				},
+			},
+			server: fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, err := w.Write([]byte(`{"id": "00000000-1111-2abc-def3-44gh55ij66kl_0"}`))
+				if err != nil {
+					t.Errorf("expected nil error, got %v", err)
+				}
+
+			})),
+		},
+	}
+
+	utils.InitializeLock()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			proxy := tc.proxy(tc.server)
+			if proxy == nil {
+				return
+			}
+
+			// Setup router
+			router := proxy.GetRouter()
+			for _, reqFunc := range tc.req {
+				req := reqFunc()
+				router.ServeHTTP(httptest.NewRecorder(), req)
+			}
+
+			t.Logf("Router: %v", router)
+		})
+	}
+}
 func TestGetRouter(t *testing.T) {
 	volumeIteratorID := "00000000-1111-2abc-def3-44gh55ij66kl_0"
 	server := fakeServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -451,61 +515,6 @@ func TestGetRouter(t *testing.T) {
 		req         []func() *http.Request
 		expectedErr error
 	}{
-		{
-			name: "Success: ServeReverseProxy - /{version}/sloprovisioning/symmetrix/{symid}",
-			proxy: func() *Proxy {
-				// Create a new Proxy
-				proxy, err := createValidProxyConfig(t, server)
-				if err != nil {
-					t.Errorf("Failed to create proxy: %v", err)
-					return nil
-				}
-
-				return proxy
-			},
-			req: []func() *http.Request{
-				func() *http.Request {
-					arrayID := "000000000001"
-					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix/%s", utils.Prefix, "9.1", arrayID)
-					req, _ := http.NewRequest("GET", url, nil)
-
-					vars := map[string]string{
-						"symid": arrayID,
-					}
-					req = mux.SetURLVars(req, vars)
-					req.SetBasicAuth("test-username", "test-password")
-					return req
-				},
-			},
-			expectedErr: nil,
-		},
-		{
-			name: "Fail: ServeReverseProxy - unauthorized",
-			proxy: func() *Proxy {
-				// Create a new Proxy
-				proxy, err := createValidProxyConfig(t, server)
-				if err != nil {
-					t.Errorf("Failed to create proxy: %v", err)
-					return nil
-				}
-
-				return proxy
-			},
-			req: []func() *http.Request{
-				func() *http.Request {
-					arrayID := "000000000001"
-					url := fmt.Sprintf("%s/%s/sloprovisioning/symmetrix/%s", utils.Prefix, "9.1", arrayID)
-					req, _ := http.NewRequest("GET", url, nil)
-
-					vars := map[string]string{
-						"symid": arrayID,
-					}
-					req = mux.SetURLVars(req, vars)
-					return req
-				},
-			},
-			expectedErr: nil,
-		},
 		{
 			name: "Success: ServeVersions - /{version}/system/version",
 			proxy: func() *Proxy {

--- a/csireverseproxy/test-config/config.yaml
+++ b/csireverseproxy/test-config/config.yaml
@@ -20,9 +20,11 @@ config:
     - url: https://backup-1.unisphe.re:8443
       arrayCredentialSecret: backup-unisphere-secret-1
       skipCertificateValidation: false
+      certSecret: "secret-cert"
     - url: https://primary-2.unisphe.re:8443
       arrayCredentialSecret: primary-unisphere-secret-2
       skipCertificateValidation: true
     - url: https://backup-2.unisphe.re:8443
       arrayCredentialSecret: backup-unisphere-secret-2
       skipCertificateValidation: false
+      certSecret: "secret-cert"

--- a/csireverseproxy/test-config/configB.yaml
+++ b/csireverseproxy/test-config/configB.yaml
@@ -1,0 +1,30 @@
+port: 2222
+config:
+  storageArrays:
+    - storageArrayId: "000000000001"
+      primaryURL: https://primary-3.unisphe.re:8443
+      backupURL: https://backup-3.unisphe.re:8443
+      proxyCredentialSecrets:
+        - primary-unisphere-secret-1
+        - backup-unisphere-secret-1
+    - storageArrayId: "000000000002"
+      primaryURL: https://primary-4.unisphe.re:8443
+      backupURL: https://backup-5.unisphe.re:8443
+      proxyCredentialSecrets:
+        - primary-unisphere-secret-2
+        - backup-unisphere-secret-2
+  managementServers:
+    - url: https://primary-3.unisphe.re:8443
+      arrayCredentialSecret: primary-unisphere-secret-1
+      skipCertificateValidation: true
+    - url: https://backup-3.unisphe.re:8443
+      arrayCredentialSecret: backup-unisphere-secret-1
+      skipCertificateValidation: false
+      certSecret: "secret-cert"
+    - url: https://primary-4.unisphe.re:8443
+      arrayCredentialSecret: primary-unisphere-secret-2
+      skipCertificateValidation: true
+    - url: https://backup-5.unisphe.re:8443
+      arrayCredentialSecret: backup-unisphere-secret-2
+      skipCertificateValidation: false
+      certSecret: "secret-cert"

--- a/csireverseproxy/test-config/configB_single.yaml
+++ b/csireverseproxy/test-config/configB_single.yaml
@@ -1,0 +1,17 @@
+port: 2222
+config:
+  storageArrays:
+    - storageArrayId: "000000000001"
+      primaryURL: https://primary-3.unisphe.re:8443
+      backupURL: https://backup-3.unisphe.re:8443
+      proxyCredentialSecrets:
+        - primary-unisphere-secret-1
+        - backup-unisphere-secret-1
+  managementServers:
+    - url: https://primary-3.unisphe.re:8443
+      arrayCredentialSecret: primary-unisphere-secret-1
+      skipCertificateValidation: true
+    - url: https://backup-3.unisphe.re:8443
+      arrayCredentialSecret: backup-unisphere-secret-1
+      skipCertificateValidation: false
+      certSecret: "secret-cert"

--- a/csireverseproxy/test-config/configB_single_noBackup.yaml
+++ b/csireverseproxy/test-config/configB_single_noBackup.yaml
@@ -1,0 +1,11 @@
+port: 2222
+config:
+  storageArrays:
+    - storageArrayId: "000000000001"
+      primaryURL: https://primary-3.unisphe.re:8443
+      proxyCredentialSecrets:
+        - primary-unisphere-secret-1
+  managementServers:
+    - url: https://primary-3.unisphe.re:8443
+      arrayCredentialSecret: primary-unisphere-secret-1
+      skipCertificateValidation: true

--- a/csireverseproxy/test-config/configC_single.yaml
+++ b/csireverseproxy/test-config/configC_single.yaml
@@ -1,0 +1,11 @@
+port: 2222
+config:
+  storageArrays:
+    - storageArrayId: "000000000003"
+      primaryURL: https://primary-1.unisphe.re:8443
+      proxyCredentialSecrets:
+        - primary-unisphere-secret-1
+  managementServers:
+    - url: https://primary-1.unisphe.re:8443
+      arrayCredentialSecret: primary-unisphere-secret-1
+      skipCertificateValidation: true


### PR DESCRIPTION
# Description
Add unit tests for the `proxy` package and ensure that it is greater than the 90% threshold.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran newly created unit tests and ensured that all other tests in reverseproxy still pass.

**Proxy Coverage**
```
PASS
coverage: 91.7% of statements
ok      revproxy/v2/pkg/proxy   0.053s  coverage: 91.7% of statements
```


**Complete Run**
<details>

```
# falfaroc @ W-39JK034 in ~/git/public/dell/csi-powermax/csireverseproxy on git:usr/falfaroc/add-proxy-test x [12:08:21]
$ make unit-test
go test -v -coverprofile c.out ./...
time="2025-02-10T12:08:50-05:00" level=info msg="Creating primary mock server..."
time="2025-02-10T12:08:50-05:00" level=info msg="Primary mock server listening on https://127.0.0.1:9104"
time="2025-02-10T12:08:50-05:00" level=info msg="Creating backup mock server..."
time="2025-02-10T12:08:50-05:00" level=info msg="Backup mock server listening on https://127.0.0.1:9109"
time="2025-02-10T12:08:50-05:00" level=info msg="Starting proxy server..."
map[config:map[managementservers:[map[arrayCredentialSecret:proxy-secret-1 certSecret:cert-secret-4 url:https://127.0.0.1:9104/] map[arrayCredentialSecret:proxy-secret-1 certSecret:cert-secret-9 url:https://127.0.0.1:9109/]] storagearrays:[map[backupURL:https://127.0.0.1:9109/ primaryURL:https://127.0.0.1:9104/ proxyCredentialSecrets:[proxy-secret-1] storageArrayId:000000000001]]] port:8080]
time="2025-02-10T12:08:50-05:00" level=info msg="Couldn't read logLevel from config file. Using debug level as default"
time="2025-02-10T12:08:50-05:00" level=info msg="Setting log level to debug"
ConfigMap: {8080   0xc0004a0ed0}
time="2025-02-10T12:08:50-05:00" level=debug msg="Successfully started the lock request handler"
time="2025-02-10T12:08:50-05:00" level=info msg="Proxy server started successfully"
=== RUN   TestServer_Start
--- PASS: TestServer_Start (0.00s)
...
=== RUN   TestNewProxy
map[config:map[managementservers:[map[arrayCredentialSecret:primary-unisphere-secret-1 skipCertificateValidation:true url:https://primary-1.unisphe.re:8443] map[arrayCredentialSecret:backup-unisphere-secret-1 certSecret:secret-cert skipCertificateValidation:false url:https://backup-1.unisphe.re:8443] map[arrayCredentialSecret:primary-unisphere-secret-2 skipCertificateValidation:true url:https://primary-2.unisphe.re:8443] map[arrayCredentialSecret:backup-unisphere-secret-2 certSecret:secret-cert skipCertificateValidation:false url:https://backup-2.unisphe.re:8443]] storagearrays:[map[backupURL:https://backup-1.unisphe.re:8443 primaryURL:https://primary-1.unisphe.re:8443 proxyCredentialSecrets:[primary-unisphere-secret-1 backup-unisphere-secret-1] storageArrayId:000000000001] map[backupURL:https://backup-2.unisphe.re:8443 primaryURL:https://primary-2.unisphe.re:8443 proxyCredentialSecrets:[primary-unisphere-secret-2 backup-unisphere-secret-2] storageArrayId:000000000002]]] port:2222]
ConfigMap: {2222   0xc000491bf0}
    proxy_test.go:64: proxyConfig: &{2222 map[000000000001:0xc0002c1a40 000000000002:0xc0000ee140] map[{https  <nil> backup-1.unisphe.re:8443   false false   }:0xc000471440 {https  <nil> backup-2.unisphe.re:8443   false false   }:0xc000471680 {https  <nil> primary-1.unisphe.re:8443   false false   }:0xc000471320 {https  <nil> primary-2.unisphe.re:8443   false false   }:0xc000471560] map[test-username:0xc0004c2200]}
--- PASS: TestNewProxy (0.00s)
=== RUN   TestUpdateConfig
map[config:map[managementservers:[map[arrayCredentialSecret:primary-unisphere-secret-1 skipCertificateValidation:true url:https://primary-1.unisphe.re:8443] map[arrayCredentialSecret:backup-unisphere-secret-1 certSecret:secret-cert skipCertificateValidation:false url:https://backup-1.unisphe.re:8443] map[arrayCredentialSecret:primary-unisphere-secret-2 skipCertificateValidation:true url:https://primary-2.unisphe.re:8443] map[arrayCredentialSecret:backup-unisphere-secret-2 certSecret:secret-cert skipCertificateValidation:false url:https://backup-2.unisphe.re:8443]] storagearrays:[map[backupURL:https://backup-1.unisphe.re:8443 primaryURL:https://primary-1.unisphe.re:8443 proxyCredentialSecrets:[primary-unisphere-secret-1 backup-unisphere-secret-1] storageArrayId:000000000001] map[backupURL:https://backup-2.unisphe.re:8443 primaryURL:https://primary-2.unisphe.re:8443 proxyCredentialSecrets:[primary-unisphere-secret-2 backup-unisphere-secret-2] storageArrayId:000000000002]]] port:2222]
ConfigMap: {2222   0xc000586750}
    proxy_test.go:97: proxyConfig: &{2222 map[000000000001:0xc0000f63c0 000000000002:0xc0000f6a00] map[{https  <nil> backup-1.unisphe.re:8443   false false   }:0xc0001d39e0 {https  <nil> backup-2.unisphe.re:8443   false false   }:0xc00033a7e0 {https  <nil> primary-1.unisphe.re:8443   false false   }:0xc0001d38c0 {https  <nil> primary-2.unisphe.re:8443   false false   }:0xc0001d3c20] map[test-username:0xc0004c2fc0]}
map[config:map[managementservers:[map[arrayCredentialSecret:primary-unisphere-secret-1 skipCertificateValidation:true url:https://primary-3.unisphe.re:8443] map[arrayCredentialSecret:backup-unisphere-secret-1 certSecret:secret-cert skipCertificateValidation:false url:https://backup-3.unisphe.re:8443] map[arrayCredentialSecret:primary-unisphere-secret-2 skipCertificateValidation:true url:https://primary-4.unisphe.re:8443] map[arrayCredentialSecret:backup-unisphere-secret-2 certSecret:secret-cert skipCertificateValidation:false url:https://backup-5.unisphe.re:8443]] storagearrays:[map[backupURL:https://backup-3.unisphe.re:8443 primaryURL:https://primary-3.unisphe.re:8443 proxyCredentialSecrets:[primary-unisphere-secret-1 backup-unisphere-secret-1] storageArrayId:000000000001] map[backupURL:https://backup-5.unisphe.re:8443 primaryURL:https://primary-4.unisphe.re:8443 proxyCredentialSecrets:[primary-unisphere-secret-2 backup-unisphere-secret-2] storageArrayId:000000000002]]] port:2222]
ConfigMap: {2222   0xc000587890}
time="2025-02-10T12:08:51-05:00" level=info msg="Changes applied successfully"
map[config:map[managementservers:[map[arrayCredentialSecret:primary-unisphere-secret-1 skipCertificateValidation:true url:https://primary-3.unisphe.re:8443] map[arrayCredentialSecret:backup-unisphere-secret-1 certSecret:secret-cert skipCertificateValidation:false url:https://backup-3.unisphe.re:8443]] storagearrays:[map[backupURL:https://backup-3.unisphe.re:8443 primaryURL:https://primary-3.unisphe.re:8443 proxyCredentialSecrets:[primary-unisphere-secret-1 backup-unisphere-secret-1] storageArrayId:000000000001]]] port:2222]
ConfigMap: {2222   0xc0001a5c80}
time="2025-02-10T12:08:51-05:00" level=info msg="Changes applied successfully"
map[config:map[managementservers:[map[arrayCredentialSecret:primary-unisphere-secret-1 skipCertificateValidation:true url:https://primary-3.unisphe.re:8443]] storagearrays:[map[primaryURL:https://primary-3.unisphe.re:8443 proxyCredentialSecrets:[primary-unisphere-secret-1] storageArrayId:000000000001]]] port:2222]
ConfigMap: {2222   0xc0002b2420}
time="2025-02-10T12:08:51-05:00" level=info msg="Changes applied successfully"
map[config:map[managementservers:[map[arrayCredentialSecret:primary-unisphere-secret-1 skipCertificateValidation:true url:https://primary-3.unisphe.re:8443] map[arrayCredentialSecret:backup-unisphere-secret-1 certSecret:secret-cert skipCertificateValidation:false url:https://backup-3.unisphe.re:8443]] storagearrays:[map[backupURL:https://backup-3.unisphe.re:8443 primaryURL:https://primary-3.unisphe.re:8443 proxyCredentialSecrets:[primary-unisphere-secret-1 backup-unisphere-secret-1] storageArrayId:000000000001]]] port:2222]
ConfigMap: {2222   0xc000458870}
time="2025-02-10T12:08:51-05:00" level=info msg="Changes applied successfully"
map[config:map[managementservers:[map[arrayCredentialSecret:primary-unisphere-secret-1 skipCertificateValidation:true url:https://primary-1.unisphe.re:8443]] storagearrays:[map[primaryURL:https://primary-1.unisphe.re:8443 proxyCredentialSecrets:[primary-unisphere-secret-1] storageArrayId:000000000003]]] port:2222]
ConfigMap: {2222   0xc0000306f0}
time="2025-02-10T12:08:51-05:00" level=info msg="Changes applied successfully"
time="2025-02-10T12:08:51-05:00" level=info msg="No changes detected in the configuration"
--- PASS: TestUpdateConfig (0.01s)
=== RUN   TestGetRouter_ServeVolume
=== RUN   TestGetRouter_ServeVolume/Success:_ServeVolume_-_/{version}/sloprovisioning/symmetrix/{symid}/volume
ConfigMap: {2222 info json 0xc000031110}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:34173-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 40.88µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:34173/univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume\n time: 368.928µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:34173-Read, Active(0/5), Queued(0/50)"
    proxy_test.go:438: Router: 0x129a540
=== RUN   TestGetRouter_ServeVolume/Success:_ServeVolume_-_with_symid_header
ConfigMap: {2222 info json 0xc00029e750}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:41583-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 21.682µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:41583/univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume\n time: 289.4µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:41583-Read, Active(0/5), Queued(0/50)"
    proxy_test.go:438: Router: 0x129a540
=== RUN   TestGetRouter_ServeVolume/Fail:_ServeVolume_-_unauthorized
ConfigMap: {2222 info json 0xc0002345a0}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume"
    proxy_test.go:438: Router: 0x129a540
=== RUN   TestGetRouter_ServeVolume/Fail:_ServeVolume_-_unauthorized_-_wrong_password
ConfigMap: {2222 info json 0xc000aa4c00}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume"
    proxy_test.go:438: Router: 0x129a540
=== RUN   TestGetRouter_ServeVolume/Fail:_ServeVolume_-_Bad_Response
ConfigMap: {2222 info json 0xc000adf260}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:33929-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 56.851µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:33929/univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume\n time: 273.343µs"
time="2025-02-10T12:08:51-05:00" level=error msg="Get Volume step fails for: (000000000001) symID with error (Not Authorised)"
    proxy_test.go:438: Router: 0x129a540
=== RUN   TestGetRouter_ServeVolume/Fail:_ServeVolume_-_Empty_Response
ConfigMap: {2222 info json 0xc000b13bf0}
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:33929-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:40495-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 18.177µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:40495/univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume\n time: 252.24µs"
time="2025-02-10T12:08:51-05:00" level=error msg="Setting iterator failed for: (000000000001) symID with error (EOF)"
    proxy_test.go:438: Router: 0x129a540
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:40495-Read, Active(0/5), Queued(0/50)"
--- PASS: TestGetRouter_ServeVolume (0.01s)
    --- PASS: TestGetRouter_ServeVolume/Success:_ServeVolume_-_/{version}/sloprovisioning/symmetrix/{symid}/volume (0.00s)
    --- PASS: TestGetRouter_ServeVolume/Success:_ServeVolume_-_with_symid_header (0.00s)
    --- PASS: TestGetRouter_ServeVolume/Fail:_ServeVolume_-_unauthorized (0.00s)
    --- PASS: TestGetRouter_ServeVolume/Fail:_ServeVolume_-_unauthorized_-_wrong_password (0.00s)
    --- PASS: TestGetRouter_ServeVolume/Fail:_ServeVolume_-_Bad_Response (0.00s)
    --- PASS: TestGetRouter_ServeVolume/Fail:_ServeVolume_-_Empty_Response (0.00s)
=== RUN   TestGetRouter_ServeReverseProxy
=== RUN   TestGetRouter_ServeReverseProxy/Success:_ServeReverseProxy_-_/{version}/sloprovisioning/symmetrix/{symid}
ConfigMap: {2222 info json 0xc000565e90}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:44329-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - Read Lock time: 37.356µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - Unisphere RESTAPI response time: 230.015µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - Total time: 304.9µs"
    proxy_test.go:527: Router: 0x129a540
=== RUN   TestGetRouter_ServeReverseProxy/Fail:_ServeReverseProxy_-_unauthorized
ConfigMap: {2222 info json 0xc000bda9f0}
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:44329-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001"
    proxy_test.go:527: Router: 0x129a540
--- PASS: TestGetRouter_ServeReverseProxy (0.00s)
    --- PASS: TestGetRouter_ServeReverseProxy/Success:_ServeReverseProxy_-_/{version}/sloprovisioning/symmetrix/{symid} (0.00s)
    --- PASS: TestGetRouter_ServeReverseProxy/Fail:_ServeReverseProxy_-_unauthorized (0.00s)
=== RUN   TestGetRouter_ServeVersions
=== RUN   TestGetRouter_ServeVersions/Success:_ServeVersions_-_/{version}/system/version
ConfigMap: {2222 info json 0xc000c9b530}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/system/version"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:44069-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 715.934µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:44069/univmax/restapi/9.1/system/version\n time: 1.372111ms"
=== RUN   TestGetRouter_ServeVersions/Success:_ServeVersions_-_with_symid_in_header
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:44069-Read, Active(0/5), Queued(0/50)"
ConfigMap: {2222 info json 0xc0000de180}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/system/version"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:32961-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - Read Lock time: 26.362µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - Unisphere RESTAPI response time: 327.656µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - Total time: 379.903µs"
=== RUN   TestGetRouter_ServeVersions/Fail:_ServeVersions_-_unauthorized
ConfigMap: {2222 info json 0xc000d80510}
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:32961-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/system/version"
=== RUN   TestGetRouter_ServeVersions/Fail:_ServeVersions_-_unauthorized_-_wrong_password
ConfigMap: {2222 info json 0xc000116b70}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/system/version"
time="2025-02-10T12:08:51-05:00" level=error msg="error : (incorrect password)"
--- PASS: TestGetRouter_ServeVersions (0.00s)
    --- PASS: TestGetRouter_ServeVersions/Success:_ServeVersions_-_/{version}/system/version (0.00s)
    --- PASS: TestGetRouter_ServeVersions/Success:_ServeVersions_-_with_symid_in_header (0.00s)
    --- PASS: TestGetRouter_ServeVersions/Fail:_ServeVersions_-_unauthorized (0.00s)
    --- PASS: TestGetRouter_ServeVersions/Fail:_ServeVersions_-_unauthorized_-_wrong_password (0.00s)
=== RUN   TestGetRouter_ServePerformance
=== RUN   TestGetRouter_ServePerformance/Success:_ServePerformance_-_/performance/Array/keys
ConfigMap: {2222 info json 0xc00011fb60}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/Array/keys"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:37611-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 69.978µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:37611/univmax/restapi/performance/Array/keys\n time: 258.739µs"
=== RUN   TestGetRouter_ServePerformance/Fail:_ServeVersions_-_unauthorized
ConfigMap: {2222 info json 0xc000402870}
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:37611-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/Array/keys"
--- PASS: TestGetRouter_ServePerformance (0.00s)
    --- PASS: TestGetRouter_ServePerformance/Success:_ServePerformance_-_/performance/Array/keys (0.00s)
    --- PASS: TestGetRouter_ServePerformance/Fail:_ServeVersions_-_unauthorized (0.00s)
=== RUN   TestGetRouter_ServeVolumePerformance
=== RUN   TestGetRouter_ServeVolumePerformance/Success:_ServeVolumePerformance_-_/performance/Volume/metrics
ConfigMap: {2222 info json 0xc0000301e0}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/Volume/metrics"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:38107-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 49.629µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:38107/univmax/restapi/performance/Volume/metrics\n time: 262.83µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:38107-Read, Active(0/5), Queued(0/50)"
=== RUN   TestGetRouter_ServeVolumePerformance/Fail:_ServeVolumePerformance_-_Empty_Body
ConfigMap: {2222 info json 0xc000c12e70}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/Volume/metrics"
time="2025-02-10T12:08:51-05:00" level=error msg="Decoding fails for mertics req for volume: EOF"
=== RUN   TestGetRouter_ServeVolumePerformance/Fail:_ServeVolumePerformance_-_Invalid_SystemID
ConfigMap: {2222 info json 0xc000565560}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/Volume/metrics"
time="2025-02-10T12:08:51-05:00" level=error msg="Authorisation step fails for: (000000000009) symID with error (failed to find array id in the configuration)"
=== RUN   TestGetRouter_ServeVolumePerformance/Fail:_ServeVolumePerformance_-_Bad_Response
ConfigMap: {2222 info json 0xc000bdbda0}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/Volume/metrics"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:33749-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 26.476µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:33749/univmax/restapi/performance/Volume/metrics\n time: 253.946µs"
time="2025-02-10T12:08:51-05:00" level=error msg="Get performace metrics step fails for: (000000000001) symID with error (Not Authorised)"
=== RUN   TestGetRouter_ServeVolumePerformance/Fail:_ServeVolumePerformance_-_Empty_Response
ConfigMap: {2222 info json 0xc000b12d80}
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:33749-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/Volume/metrics"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:39173-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 37.742µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:39173/univmax/restapi/performance/Volume/metrics\n time: 428.093µs"
time="2025-02-10T12:08:51-05:00" level=error msg="decoding error: EOF"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:39173-Read, Active(0/5), Queued(0/50)"
--- PASS: TestGetRouter_ServeVolumePerformance (0.00s)
    --- PASS: TestGetRouter_ServeVolumePerformance/Success:_ServeVolumePerformance_-_/performance/Volume/metrics (0.00s)
    --- PASS: TestGetRouter_ServeVolumePerformance/Fail:_ServeVolumePerformance_-_Empty_Body (0.00s)
    --- PASS: TestGetRouter_ServeVolumePerformance/Fail:_ServeVolumePerformance_-_Invalid_SystemID (0.00s)
    --- PASS: TestGetRouter_ServeVolumePerformance/Fail:_ServeVolumePerformance_-_Bad_Response (0.00s)
    --- PASS: TestGetRouter_ServeVolumePerformance/Fail:_ServeVolumePerformance_-_Empty_Response (0.00s)
=== RUN   TestGetRouter_ServeFSPerformance
=== RUN   TestGetRouter_ServeFSPerformance/Success:_ServeFSPerformance_-_/performance/file/filesystem/metrics
ConfigMap: {2222 info json 0xc000ade270}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/file/filesystem/metrics"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:39361-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 31.197µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:39361/univmax/restapi/performance/file/filesystem/metrics\n time: 204.283µs"
=== RUN   TestGetRouter_ServeFSPerformance/Fail:_ServeFSPerformance_-_Empty_Body
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:39361-Read, Active(0/5), Queued(0/50)"
ConfigMap: {2222 info json 0xc00029ec60}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/file/filesystem/metrics"
time="2025-02-10T12:08:51-05:00" level=error msg="Decoding fails for mertics req for volume: EOF"
=== RUN   TestGetRouter_ServeFSPerformance/Fail:_ServeFSPerformance_-_Invalid_SystemID
ConfigMap: {2222 info json 0xc000231bc0}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/file/filesystem/metrics"
time="2025-02-10T12:08:51-05:00" level=error msg="Authorisation step fails for: (000000000009) symID with error (failed to find array id in the configuration)"
=== RUN   TestGetRouter_ServeFSPerformance/Fail:_ServeFSPerformance_-_Bad_Response
ConfigMap: {2222 info json 0xc000caa570}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/file/filesystem/metrics"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:41037-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 46.491µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:41037/univmax/restapi/performance/file/filesystem/metrics\n time: 253.666µs"
time="2025-02-10T12:08:51-05:00" level=error msg="Get performace metrics step fails for: (000000000001) symID with error (Not Authorised)"
=== RUN   TestGetRouter_ServeFSPerformance/Fail:_ServeFSPerformance_-_Empty_Response
ConfigMap: {2222 info json 0xc000234ab0}
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:41037-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/performance/file/filesystem/metrics"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:39975-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 33.825µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:39975/univmax/restapi/performance/file/filesystem/metrics\n time: 301.428µs"
time="2025-02-10T12:08:51-05:00" level=error msg="decoding error: EOF"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:39975-Read, Active(0/5), Queued(0/50)"
--- PASS: TestGetRouter_ServeFSPerformance (0.00s)
    --- PASS: TestGetRouter_ServeFSPerformance/Success:_ServeFSPerformance_-_/performance/file/filesystem/metrics (0.00s)
    --- PASS: TestGetRouter_ServeFSPerformance/Fail:_ServeFSPerformance_-_Empty_Body (0.00s)
    --- PASS: TestGetRouter_ServeFSPerformance/Fail:_ServeFSPerformance_-_Invalid_SystemID (0.00s)
    --- PASS: TestGetRouter_ServeFSPerformance/Fail:_ServeFSPerformance_-_Bad_Response (0.00s)
    --- PASS: TestGetRouter_ServeFSPerformance/Fail:_ServeFSPerformance_-_Empty_Response (0.00s)
=== RUN   TestGetRouter_ServeIterator
=== RUN   TestGetRouter_ServeIterator/Success:_ServeIterator_-_/common/Iterator/{iterId}/page
ConfigMap: {2222 info json 0xc000e0ce40}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:40235-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 28.124µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:40235/univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume\n time: 198.5µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 2 - GET /univmax/restapi/common/Iterator/00000000-1111-2abc-def3-44gh55ij66kl_0/page"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:40235-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:40235-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 2 - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 2 - Read Lock time: 34.568µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 2 - GET http://127.0.0.1:40235/univmax/restapi/common/Iterator/00000000-1111-2abc-def3-44gh55ij66kl_0/page\n time: 262.638µs"
=== RUN   TestGetRouter_ServeIterator/Fail:_ServeIterator_-_missing_iterator_id
ConfigMap: {2222 info json 0xc000d80930}
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:40235-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/common/Iterator/00000000-1111-2abc-def3-44gh55ij66kl_0/page"
=== RUN   TestGetRouter_ServeIterator/Fail:_ServeIterator_-_unauthorized
ConfigMap: {2222 info json 0xc00011f470}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:45155-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 27.906µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:45155/univmax/restapi/9.1/sloprovisioning/symmetrix/000000000001/volume\n time: 223.226µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:45155-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 2 - GET /univmax/restapi/common/Iterator/00000000-1111-2abc-def3-44gh55ij66kl_0/page"
--- PASS: TestGetRouter_ServeIterator (0.00s)
    --- PASS: TestGetRouter_ServeIterator/Success:_ServeIterator_-_/common/Iterator/{iterId}/page (0.00s)
    --- PASS: TestGetRouter_ServeIterator/Fail:_ServeIterator_-_missing_iterator_id (0.00s)
    --- PASS: TestGetRouter_ServeIterator/Fail:_ServeIterator_-_unauthorized (0.00s)
=== RUN   TestGetRouter_ServeSymmetrix
=== RUN   TestGetRouter_ServeSymmetrix/Success:_ServeSymmetrix_-_/{version}/sloprovisioning/symmetrix
ConfigMap: {2222 info json 0xc000403110}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/1.0/sloprovisioning/symmetrix"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:33451-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 29.797µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:33451/univmax/restapi/1.0/sloprovisioning/symmetrix\n time: 193.472µs"
=== RUN   TestGetRouter_ServeSymmetrix/Fail:_ServeSymmetrix_-_unauthorized
ConfigMap: {2222 info json 0xc000030150}
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:33451-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/1.0/sloprovisioning/symmetrix"
=== RUN   TestGetRouter_ServeSymmetrix/Fail:_ServeSymmetrix_-_Bad_Response
ConfigMap: {2222 info json 0xc000c12990}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/1.0/sloprovisioning/symmetrix"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:38529-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 40.289µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:38529/univmax/restapi/1.0/sloprovisioning/symmetrix\n time: 236.811µs"
time="2025-02-10T12:08:51-05:00" level=error msg="Get Symmetrix step fails for: (000000000001) symID with error (Not Authorised)"
=== RUN   TestGetRouter_ServeSymmetrix/Fail:_ServeSymmetrix_-_Illformed_Response
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:38529-Read, Active(0/5), Queued(0/50)"
ConfigMap: {2222 info json 0xc000cd0300}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/1.0/sloprovisioning/symmetrix"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:39413-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 63.436µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:39413/univmax/restapi/1.0/sloprovisioning/symmetrix\n time: 336.307µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:39413-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=error msg="decoding error: json: cannot unmarshal string into Go value of type v100.SymmetrixIDList"
=== RUN   TestGetRouter_ServeSymmetrix/Fail:_ServeSymmetrix_-_Empty_Response
ConfigMap: {2222 info json 0xc000bdae70}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/1.0/sloprovisioning/symmetrix"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:45395-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 45.971µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:45395/univmax/restapi/1.0/sloprovisioning/symmetrix\n time: 233.386µs"
--- PASS: TestGetRouter_ServeSymmetrix (0.00s)
    --- PASS: TestGetRouter_ServeSymmetrix/Success:_ServeSymmetrix_-_/{version}/sloprovisioning/symmetrix (0.00s)
    --- PASS: TestGetRouter_ServeSymmetrix/Fail:_ServeSymmetrix_-_unauthorized (0.00s)
    --- PASS: TestGetRouter_ServeSymmetrix/Fail:_ServeSymmetrix_-_Bad_Response (0.00s)
    --- PASS: TestGetRouter_ServeSymmetrix/Fail:_ServeSymmetrix_-_Illformed_Response (0.00s)
    --- PASS: TestGetRouter_ServeSymmetrix/Fail:_ServeSymmetrix_-_Empty_Response (0.00s)
=== RUN   TestGetRouter_ServeReplicationCapabilities
=== RUN   TestGetRouter_ServeReplicationCapabilities/Success:_ServeReplicationCapabilities_-_/{version}/replication/capabilities/symmetrix
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:45395-Read, Active(0/5), Queued(0/50)"
ConfigMap: {2222 info json 0xc000aa66f0}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/1.0/replication/capabilities/symmetrix"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:33873-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 23.377µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:33873/univmax/restapi/1.0/replication/capabilities/symmetrix\n time: 821.978µs"
=== RUN   TestGetRouter_ServeReplicationCapabilities/Fail:_ServeReplicationCapabilities_-_unauthorized
ConfigMap: {2222 info json 0xc000b122d0}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/1.0/replication/capabilities/symmetrix"
=== RUN   TestGetRouter_ServeReplicationCapabilities/Fail:_ServeReplicationCapabilities_-_Bad_Response
ConfigMap: {2222 info json 0xc000564a50}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/1.0/replication/capabilities/symmetrix"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:33873-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:35947-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 368.445µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:35947/univmax/restapi/1.0/replication/capabilities/symmetrix\n time: 618.317µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:35947-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=error msg="Get Repelication capabilities step fails for: (000000000001) symID with error (Not Authorised)"
=== RUN   TestGetRouter_ServeReplicationCapabilities/Fail:_ServeReplicationCapabilities_-_Illformed_Response
ConfigMap: {2222 info json 0xc00029ec00}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/1.0/replication/capabilities/symmetrix"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:40887-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 33.328µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:40887/univmax/restapi/1.0/replication/capabilities/symmetrix\n time: 243.595µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:40887-Read, Active(0/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=error msg="decoding error: json: cannot unmarshal string into Go value of type v100.SymReplicationCapabilities"
=== RUN   TestGetRouter_ServeReplicationCapabilities/Fail:_ServeReplicationCapabilities_-_Empty_Response
ConfigMap: {2222 info json 0xc000cab470}
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 1 - GET /univmax/restapi/1.0/replication/capabilities/symmetrix"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:38521-Read, Active(1/5), Queued(0/50)"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Obtained Read lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - Read Lock time: 32.212µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID:  - GET http://127.0.0.1:38521/univmax/restapi/1.0/replication/capabilities/symmetrix\n time: 183.586µs"
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: http://127.0.0.1:38521-Read, Active(0/5), Queued(0/50)"
--- PASS: TestGetRouter_ServeReplicationCapabilities (0.00s)
    --- PASS: TestGetRouter_ServeReplicationCapabilities/Success:_ServeReplicationCapabilities_-_/{version}/replication/capabilities/symmetrix (0.00s)
    --- PASS: TestGetRouter_ServeReplicationCapabilities/Fail:_ServeReplicationCapabilities_-_unauthorized (0.00s)
    --- PASS: TestGetRouter_ServeReplicationCapabilities/Fail:_ServeReplicationCapabilities_-_Bad_Response (0.00s)
    --- PASS: TestGetRouter_ServeReplicationCapabilities/Fail:_ServeReplicationCapabilities_-_Illformed_Response (0.00s)
    --- PASS: TestGetRouter_ServeReplicationCapabilities/Fail:_ServeReplicationCapabilities_-_Empty_Response (0.00s)
PASS
coverage: 91.7% of statements
ok      revproxy/v2/pkg/proxy   0.053s  coverage: 91.7% of statements
=== RUN   TestGetHandler
=== RUN   TestGetHandler/Version_Endpoint
=== RUN   TestGetHandler/Symmetrix_Endpoint
=== RUN   TestGetHandler/Auth_Endpoint
=== RUN   TestGetHandler/Timeout_Endpoint
--- PASS: TestGetHandler (0.00s)
    --- PASS: TestGetHandler/Version_Endpoint (0.00s)
    --- PASS: TestGetHandler/Symmetrix_Endpoint (0.00s)
    --- PASS: TestGetHandler/Auth_Endpoint (0.00s)
    --- PASS: TestGetHandler/Timeout_Endpoint (0.00s)
=== RUN   TestHandleVolume
--- PASS: TestHandleVolume (0.00s)
=== RUN   TestHandleSymmCapabilities2
--- PASS: TestHandleSymmCapabilities2 (0.00s)
=== RUN   TestHandleDefault
--- PASS: TestHandleDefault (0.00s)
PASS
coverage: 100.0% of statements
ok      revproxy/v2/pkg/servermock      0.007s  coverage: 100.0% of statements
=== RUN   TestLock
=== RUN   TestLock/Successful_Lock_Acquisition
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 12345 - Obtained READ lock"
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 12345 - READ Lock time: 50.41165ms"
Lock acquired successfully for: Successful Lock Acquisition
=== RUN   TestLock/Failed_Lock_Acquisition
time="2025-02-10T12:08:51-05:00" level=info msg="Request ID: 67890 - WRITE Lock time: 50.301705ms"
Expected failure occurred for: Failed Lock Acquisition
--- PASS: TestLock (0.10s)
    --- PASS: TestLock/Successful_Lock_Acquisition (0.05s)
    --- PASS: TestLock/Failed_Lock_Acquisition (0.05s)
=== RUN   TestReleaseLock
=== RUN   TestReleaseLock/Successful_Lock_Release
Releasing lock for: Successful Lock Release
Lock released successfully for: Successful Lock Release
=== RUN   TestReleaseLock/Failed_Lock_Release_-_Invalid_Lock
Releasing lock for: Failed Lock Release - Invalid Lock
Expected failure occurred for lock release: Failed Lock Release - Invalid Lock
--- PASS: TestReleaseLock (0.00s)
    --- PASS: TestReleaseLock/Successful_Lock_Release (0.00s)
    --- PASS: TestReleaseLock/Failed_Lock_Release_-_Invalid_Lock (0.00s)
=== RUN   TestLockRequestHandler
=== RUN   TestLockRequestHandler/Successful_Lock_Request
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: test-resource-1, Active(1/1), Queued(0/1)"
Processed lock request for: Successful Lock Request
=== RUN   TestLockRequestHandler/Successful_Lock_Release
time="2025-02-10T12:08:51-05:00" level=info msg="Lock: test-resource-1, Active(0/1), Queued(0/1)"
Processed lock request for: Successful Lock Release
--- PASS: TestLockRequestHandler (0.30s)
    --- PASS: TestLockRequestHandler/Successful_Lock_Request (0.10s)
    --- PASS: TestLockRequestHandler/Successful_Lock_Release (0.10s)
=== RUN   TestInitializeLock
InitializeLock executed successfully
--- PASS: TestInitializeLock (0.00s)
=== RUN   TestDeleteEntryFromMap
deleteEntryFromMap executed successfully
--- PASS: TestDeleteEntryFromMap (0.00s)
=== RUN   TestWriteHTTPError
--- PASS: TestWriteHTTPError (0.00s)
=== RUN   TestIsStringInSlice
--- PASS: TestIsStringInSlice (0.00s)
=== RUN   TestBasicAuth
--- PASS: TestBasicAuth (0.00s)
=== RUN   TestGetRequestType
--- PASS: TestGetRequestType (0.00s)
=== RUN   TestIsValidResponse
=== RUN   TestIsValidResponse/Nil_response
=== RUN   TestIsValidResponse/Unauthorized_response
=== RUN   TestIsValidResponse/Internal_Server_Error_response
=== RUN   TestIsValidResponse/Invalid_response
=== RUN   TestIsValidResponse/Valid_response
=== RUN   TestIsValidResponse/Valid_response_within_range
--- PASS: TestIsValidResponse (0.00s)
    --- PASS: TestIsValidResponse/Nil_response (0.00s)
    --- PASS: TestIsValidResponse/Unauthorized_response (0.00s)
    --- PASS: TestIsValidResponse/Internal_Server_Error_response (0.00s)
    --- PASS: TestIsValidResponse/Invalid_response (0.00s)
    --- PASS: TestIsValidResponse/Valid_response (0.00s)
    --- PASS: TestIsValidResponse/Valid_response_within_range (0.00s)
=== RUN   TestAppendIfMissingStringSlice
--- PASS: TestAppendIfMissingStringSlice (0.00s)
=== RUN   TestRemoveTempFiles
--- PASS: TestRemoveTempFiles (0.00s)
=== RUN   TestWriteHTTPResponse
error: json: unsupported type: chan int
time="2025-02-10T12:08:51-05:00" level=error msg="Couldn't write to ResponseWriter"
Mock WriteHeader called with status: 500--- PASS: TestWriteHTTPResponse (0.00s)
=== RUN   TestGetMaxActive
--- PASS: TestGetMaxActive (0.00s)
=== RUN   TestGetMaxOutStanding
--- PASS: TestGetMaxOutStanding (0.00s)
=== RUN   TestGetListenAddress
--- PASS: TestGetListenAddress (0.00s)
PASS
coverage: 90.6% of statements
ok      revproxy/v2/pkg/utils   0.412s  coverage: 90.6% of statements
```
</details>