### PR TITLE
Fix data races in reverse proxy unit tests

### DIFF
--- a/csireverseproxy/main_test.go
+++ b/csireverseproxy/main_test.go
@@ -22,7 +22,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -188,7 +188,7 @@ func doHTTPRequest(port, path string) (string, error) {
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -755,7 +755,6 @@ func TestRun(t *testing.T) {
 		{
 			name: "execute run sucess",
 			setup: func() {
-
 				t.Setenv(common.EnvIsLeaderElectionEnabled, "false")
 				startServerFunc = func(k8sUtils k8sutils.UtilsInterface, opts ServerOpts) (*Server, error) {
 					return &Server{
@@ -780,7 +779,6 @@ func TestRun(t *testing.T) {
 		{
 			name: "execute run start server failure",
 			setup: func() {
-
 				t.Setenv(common.EnvIsLeaderElectionEnabled, "false")
 				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
 					return &k8sutils.K8sUtils{
@@ -801,7 +799,6 @@ func TestRun(t *testing.T) {
 		{
 			name: "execute run k8s init failure",
 			setup: func() {
-
 				t.Setenv(common.EnvIsLeaderElectionEnabled, "false")
 				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
 					return nil, errors.New("error, k8s init failed")
@@ -925,7 +922,7 @@ func TestK8sInitFunc(t *testing.T) {
 
 func TestStartServerFuncFailure(t *testing.T) {
 	opts := getServerOpts()
-	//Invalid config file
+	// Invalid config file
 	opts.ConfigFileName = "invalid.yaml"
 	opts.ConfigDir = "./invalid-dir"
 	_, err := startServerFunc(k8smock.Init(), opts)

--- a/csireverseproxy/main_test.go
+++ b/csireverseproxy/main_test.go
@@ -570,7 +570,10 @@ func TestMainFunc(t *testing.T) {
 			setup: func() {
 				t.Setenv(common.EnvIsLeaderElectionEnabled, "false")
 				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
-					runningCh <- "not running"
+					// must defer writing to the channel so all goroutines can finish running,
+					// avoiding data races triggered by resetting the default func vars in the afterEach() func.
+					defer func() { runningCh <- "not running" }()
+
 					return nil, errors.New("error, k8s init failed")
 				}
 			},
@@ -599,7 +602,10 @@ func TestMainFunc(t *testing.T) {
 				}
 
 				runWithLeaderElectionFunc = func(_ *k8sutils.KubernetesClient) (err error) {
-					runningCh <- "not running"
+					// must defer writing to the channel so all goroutines can finish running,
+					// avoiding data races triggered by resetting the default func vars in the afterEach() func.
+					defer func() { runningCh <- "not running" }()
+
 					ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 					defer cancel()
 
@@ -644,7 +650,10 @@ func TestMainFunc(t *testing.T) {
 				}
 
 				k8sInitFunc = func(namespace string, certDir string, isInCluster bool, resyncPeriod time.Duration, kubeClient *k8sutils.KubernetesClient) (*k8sutils.K8sUtils, error) {
-					runningCh <- "not running"
+					// must defer writing to the channel so all goroutines can finish running,
+					// avoiding data races triggered by resetting the default func vars in the afterEach() func.
+					defer func() { runningCh <- "not running" }()
+
 					return nil, errors.New("error, k8s init failed")
 				}
 			},
@@ -657,7 +666,10 @@ func TestMainFunc(t *testing.T) {
 			setup: func() {
 				t.Setenv(common.EnvIsLeaderElectionEnabled, "false")
 				startServerFunc = func(k8sUtils k8sutils.UtilsInterface, opts ServerOpts) (*Server, error) {
-					runningCh <- "running"
+					// must defer writing to the channel so all goroutines can finish running,
+					// avoiding data races triggered by resetting the default func vars in the afterEach() func.
+					defer func() { runningCh <- "running" }()
+
 					return &Server{
 						Opts: opts,
 					}, nil

--- a/csireverseproxy/main_test.go
+++ b/csireverseproxy/main_test.go
@@ -259,7 +259,7 @@ func createTempConfig() error {
 	}
 
 	filename := tmpSAConfigFile
-	proxyConfigMap.Port = "8080"
+	proxyConfigMap.Port = "2222"
 	// Create a ManagementServerConfig
 	tempMgmtServerConfig := createTempManagementServers()
 	proxyConfigMap.Config.ManagementServerConfig = tempMgmtServerConfig

--- a/csireverseproxy/pkg/cache/cache_test.go
+++ b/csireverseproxy/pkg/cache/cache_test.go
@@ -111,6 +111,8 @@ func TestCleanupCallback2(t *testing.T) {
 			cleanup := c.cleanupCallback(tt.cleanupKey)
 			cleanup()
 
+			c.cmu.Lock()
+			defer c.cmu.Unlock()
 			_, exists := c.store[tt.cleanupKey]
 			if exists != tt.expectedExists {
 				t.Fatalf("Expected key existence: %v, got: %v", tt.expectedExists, exists)

--- a/csireverseproxy/pkg/utils/locks_test.go
+++ b/csireverseproxy/pkg/utils/locks_test.go
@@ -17,9 +17,10 @@ package utils
 
 import (
 	"fmt"
-	"revproxy/v2/pkg/common"
 	"testing"
 	"time"
+
+	"revproxy/v2/pkg/common"
 )
 
 func TestLock(t *testing.T) {
@@ -57,8 +58,11 @@ func TestLock(t *testing.T) {
 
 			// Simulate lock processing asynchronously
 			go func() {
-				time.Sleep(50 * time.Millisecond)
-				lock.WaitChannel <- tt.lockResult
+				// wait for the request to be queued in lock.Lock()
+				req := <-lockRequestsQueue
+				lockMutex.Lock()
+				defer lockMutex.Unlock()
+				req.WaitChannel <- tt.lockResult
 			}()
 
 			err := lock.Lock()


### PR DESCRIPTION
# Description
Resolving some data races observed in tests for csireverseproxy module.
> Note: these are being merged to the branch for ongoing efforts to increase code coverage.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Ran several test runs with `-race` flag enabled and received no data race warnings.
```bash
[csireverseproxy]$ sudo go test -race -cover -timeout 30s ./...
ok      revproxy/v2     4.734s  coverage: 90.3% of statements
ok      revproxy/v2/pkg/cache   1.073s  coverage: 100.0% of statements
ok      revproxy/v2/pkg/common  3.138s  coverage: 92.0% of statements
ok      revproxy/v2/pkg/config  1.428s  coverage: 90.9% of statements
ok      revproxy/v2/pkg/k8smock 1.294s  coverage: 92.4% of statements
ok      revproxy/v2/pkg/k8sutils        1.253s  coverage: 91.3% of statements
ok      revproxy/v2/pkg/proxy   1.476s  coverage: 91.6% of statements
ok      revproxy/v2/pkg/servermock      1.046s  coverage: 100.0% of statements
ok      revproxy/v2/pkg/utils   1.344s  coverage: 90.6% of statements
```
