### PR TITLE
Fix data race in deletion_worker.go

### DIFF
--- a/service/locks.go
+++ b/service/locks.go
@@ -149,7 +149,6 @@ func CleanupMapEntries(duration time.Duration) {
 				lockMutex.Lock()
 				// Don't hold the mutex for more than 20 milliseconds
 				now := time.Now()
-				log.Debugf("CleanupMapEntries: Current number of entries in lock map: %d", len(fifolocks))
 				for resourceID, lockInfo := range fifolocks {
 					if time.Since(now) > 20*time.Millisecond {
 						log.Debugf("CleanupMapEntries: Held the lock mutex for 20 milliseconds. Releasing it now")


### PR DESCRIPTION
# Description
Refactoring adding volumes to deletion queue
Running `populateDeletionQueue()` as a goroutine was causing data races with unsafe concurrent access to the http client of the powermax client while running powermax REST API queries.
Instead of running the whole function as a goroutine, only create goroutines for queue insertion operations. Since the queue insertion function needs no reference to the powermax client, there should be no issues.

Also removed a log message in locks.go that printed every 20ms.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 85% and 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
