### PR TITLE
Updating Go Version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/csi-powermax/v2
 
-go 1.23.5
+go 1.23.0
 
 require (
 	github.com/akutz/goof v0.1.2


### PR DESCRIPTION
# Description
PR for updating the go version of go.mod to v1.23.0, to make it consistent with the go version specified in csm-common.mk

There are issues seen while building the image for CSI Powermax and Reverse Proxy from the main branch due to inconsistency in the go version in the go.mod file of CSI Powermax and go version mentioned in csm-common.mk which is used for building the images - https://github.com/dell/csm/blob/main/config/csm-common.mk#L30


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- [x] Vetting checks are passing for both CSI Powermax and CSI Reverse Proxy while building the images. 
- [x] Both CSI Powermax and CSI Reverse Proxy images are getting build successfully. 
