### PR TITLE
Fix the inCluster environment name

### DIFF
--- a/csireverseproxy/manifests/revproxy.yaml
+++ b/csireverseproxy/manifests/revproxy.yaml
@@ -68,7 +68,7 @@ spec:
               value: /etc/config/configmap
             - name: X_CSI_REVPROXY_CONFIG_FILE_NAME
               value: config.yaml
-            - name: X_CSI_REVRPOXY_IN_CLUSTER
+            - name: X_CSI_REVPROXY_IN_CLUSTER
               value: "true"
             - name: X_CSI_REVPROXY_TLS_CERT_DIR
               value: /app/tls

--- a/csireverseproxy/pkg/common/constants.go
+++ b/csireverseproxy/pkg/common/constants.go
@@ -32,7 +32,7 @@ const (
 	EnvWatchNameSpace           = "X_CSI_REVPROXY_WATCH_NAMESPACE"
 	EnvConfigFileName           = "X_CSI_REVPROXY_CONFIG_FILE_NAME"
 	EnvConfigDirName            = "X_CSI_REVPROXY_CONFIG_DIR"
-	EnvInClusterConfig          = "X_CSI_REVRPOXY_IN_CLUSTER"
+	EnvInClusterConfig          = "X_CSI_REVPROXY_IN_CLUSTER"
 	EnvIsLeaderElectionEnabled  = "X_CSI_REVPROXY_IS_LEADER_ENABLED"
 	EnvSecretFilePath           = "X_CSI_REVPROXY_SECRET_FILEPATH"
 	EnvReverseProxyUseSecret    = "X_CSI_REVPROXY_USE_SECRET"


### PR DESCRIPTION
# Description
Fix the variable name reference for inCluster to `X_CSI_REVPROXY_IN_CLUSTER`.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1614 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- [x] Tested with Operator to ensure the lookup was working as expected (https://github.com/dell/csm-operator/pull/892).
