### PR TITLE
Cleanup obsolete Makefile/Dockerfile entries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 #
 include overrides.mk
 
-all: clean build
+all: build unit-test
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -30,11 +30,7 @@ clean:
 
 build:
 	go generate
-	CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
-
-install:
-	go generate
-	GOOS=linux CGO_ENABLED=0 go install
+	CGO_ENABLED=0 go build
 
 # Generates the docker container (but does not push)
 docker:
@@ -59,11 +55,11 @@ push:	docker
 
 # Run unit tests and skip the BDD tests
 unit-test:
-	( cd service; go clean -cache; CGO_ENABLED=0 GO111MODULE=on go test -v -coverprofile=c.out ./... )
+	( cd service; go clean -cache; CGO_ENABLED=0 go test -v -coverprofile=c.out ./... )
 
 # Run BDD tests. Need to be root to run as tests require some system access, need to fix
 bdd-test:
-	( cd service; go clean -cache; CGO_ENABLED=0 GO111MODULE=on go test -run TestGoDog -v -coverprofile=c.out ./... )
+	( cd service; go clean -cache; CGO_ENABLED=0 go test -run TestGoDog -v -coverprofile=c.out ./... )
 
 # Linux only; populate env.sh with the hardware parameters
 integration-test:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Repository for CSI Driver for Dell PowerMax**
 
 ## Description
-CSI Driver for PowerMax is part of the [CSM (Container Storage Modules)](https://github.com/dell/csm) open-source suite of Kubernetes storage enablers for Dell products. CSI Driver for PowerMax is a Container Storage Interface (CSI) driver that provides support for provisioning persistent storage using Dell PowerMax storage array. 
+CSI Driver for PowerMax is part of the [CSM (Container Storage Modules)](https://github.com/dell/csm) open-source suite of Kubernetes storage enablers for Dell products. The CSI Driver for PowerMax is a Container Storage Interface (CSI) driver that provides support for provisioning persistent storage using Dell PowerMax storage array.
 
 It supports CSI specification version 1.6.
 
@@ -32,20 +32,17 @@ This project may be compiled as a stand-alone binary using Golang that, when run
 For any CSI driver issues, questions or feedback, please follow our [support process](https://github.com/dell/csm/blob/main/docs/SUPPORT.md)
 
 ## Building
-This project is a Go module (see golang.org Module information for explanation). 
-The dependencies for this project are in the go.mod file.
 
-To build the source, execute `make clean build`.
+To build the source, execute `make build`.
 
 To run unit tests, execute `make unit-test`.
 
-To build an image, copy all dependent repos (see Dockerfile.sh) into the same folder with csi-powermax, then `cd` into `csi-powermax` and execute `make docker`.
+To build an image, execute `make docker`.
 
 You can run an integration test on a Linux system by populating the file `env.sh` with values for your Dell PowerMax systems and then run "`make integration-test`".
 
 ## Runtime Dependencies
 For a complete list of dependencies, please visit [Prerequisites](https://dell.github.io/csm-docs/docs/deployment/helm/drivers/installation/powermax/#prerequisites)
-
 
 ## Driver Installation
 Please consult the [Installation Guide](https://dell.github.io/csm-docs/docs/deployment/)

--- a/csireverseproxy/Dockerfile
+++ b/csireverseproxy/Dockerfile
@@ -15,6 +15,7 @@
 ############################
 ARG GOIMAGE
 ARG BASEIMAGE
+ARG GOPROXY
 
 FROM $GOIMAGE as builder
 

--- a/csireverseproxy/Makefile
+++ b/csireverseproxy/Makefile
@@ -22,9 +22,9 @@ clean:
 	go clean
 
 build:
-	CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build
+	CGO_ENABLED=0 go build
 
-docker: build
+docker:
 	go run ../core/semver/semver.go -f mk >semver.mk
 	make -f docker.mk docker
 


### PR DESCRIPTION
# Description

The reverseproxy image build is building twice. This may have been due to the legacy Dockerfile, before the two build was introduced. Also cleaned up some obsolete build targets and Go build options.


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [X] Have you run format,vet & lint checks against your submission?
- [X] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Ran the two images the verify that they start without any linker errors. Installed driver and proxy in K8s cluster. Ran cert-csi vio test suite.
