### PR TITLE
Updated the snapshot size

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -3289,11 +3289,14 @@ func (s *service) CreateSnapshot(
 			"Could not find source volume on the array")
 	}
 
+	snapBytes := int64(vol.CapacityGB * 1024 * 1024 * 1024)
+	
 	// Is it an idempotent request?
 	snapInfo, err := pmaxClient.GetSnapshotInfo(ctx, symID, devID, snapID)
 	if err == nil && snapInfo.VolumeSnapshotSource != nil {
 		snapID = fmt.Sprintf("%s-%s-%s", snapID, symID, devID)
 		snapshot := &csi.Snapshot{
+			SizeBytes:      snapBytes,
 			SnapshotId:     snapID,
 			SourceVolumeId: volID, ReadyToUse: true,
 			CreationTime: timestamppb.Now(),
@@ -3327,7 +3330,7 @@ func (s *service) CreateSnapshot(
 	}
 
 	snapID = fmt.Sprintf("%s-%s-%s", snap.SnapshotName, symID, devID)
-	snapBytes := int64(vol.CapacityGB * 1024 * 1024 * 1024)
+	
 	// populate response structure
 	snapshot := &csi.Snapshot{
 		SizeBytes:      snapBytes,

--- a/service/controller.go
+++ b/service/controller.go
@@ -3327,9 +3327,10 @@ func (s *service) CreateSnapshot(
 	}
 
 	snapID = fmt.Sprintf("%s-%s-%s", snap.SnapshotName, symID, devID)
+	snapBytes := int64(vol.CapacityGB * 1024 * 1024 * 1024)
 	// populate response structure
 	snapshot := &csi.Snapshot{
-		SizeBytes:      int64(cylinderSizeInBytes * vol.CapacityCYL),
+		SizeBytes:      snapBytes,
 		SnapshotId:     snapID,
 		SourceVolumeId: volID,
 		ReadyToUse:     true,

--- a/service/controller.go
+++ b/service/controller.go
@@ -3290,7 +3290,7 @@ func (s *service) CreateSnapshot(
 	}
 
 	snapBytes := int64(vol.CapacityGB * 1024 * 1024 * 1024)
-	
+
 	// Is it an idempotent request?
 	snapInfo, err := pmaxClient.GetSnapshotInfo(ctx, symID, devID, snapID)
 	if err == nil && snapInfo.VolumeSnapshotSource != nil {
@@ -3330,7 +3330,6 @@ func (s *service) CreateSnapshot(
 	}
 
 	snapID = fmt.Sprintf("%s-%s-%s", snap.SnapshotName, symID, devID)
-	
 	// populate response structure
 	snapshot := &csi.Snapshot{
 		SizeBytes:      snapBytes,

--- a/service/features/snapshot.feature
+++ b/service/features/snapshot.feature
@@ -42,6 +42,7 @@ Feature: PowerMax CSI Interface
         When I call CreateSnapshot "snapshot1" on "volume1"
         And I call CreateSnapshot "snapshot1" on "volume1"
         Then a valid CreateSnapshotResponse is returned
+        And I validate the snapshot SizeBytes matches the volume CapacityGB
 @v1.2.0
     Scenario: Create a snapshot on a volume which is already in a snap session
         Given a PowerMax service

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -5192,26 +5192,22 @@ func (f *feature) iCallArrayMigrate(actionvalue string, parameter string) error 
 	return nil
 }
 
-func (f* feature) validateSnapshotSizeBytesMatchesVolumeCapacityGB() error {
+func (f *feature) validateSnapshotSizeBytesMatchesVolumeCapacityGB() error {
 	if f.err != nil {
-        return f.err
-    }
-    if f.createSnapshotResponse == nil || f.createSnapshotResponse.Snapshot == nil {
-        return errors.New("Expected a valid createSnapshotResponse")
-    }
-    
+		return f.err
+	}
+	if f.createSnapshotResponse == nil || f.createSnapshotResponse.Snapshot == nil {
+		return errors.New("Expected a valid createSnapshotResponse")
+	}
+
 	_, _, vol, _ := f.service.GetVolumeByID(context.Background(), f.volumeID, f.service.adminClient)
-    expectedSizeBytes := int64(vol.CapacityGB)
+	expectedSizeBytes := int64(vol.CapacityGB)
 
-	log.Println("expected size: ", expectedSizeBytes)
-	log.Println("Snapshot size: ", f.createSnapshotResponse.Snapshot.SizeBytes)
+	if f.createSnapshotResponse.Snapshot.SizeBytes != expectedSizeBytes {
+		return errors.New("SizeBytes in response should match the volume's CapacityGB")
+	}
 
-	
-    if f.createSnapshotResponse.Snapshot.SizeBytes != expectedSizeBytes {
-        return errors.New("SizeBytes in response should match the volume's CapacityGB")
-    }
-    
-    return nil
+	return nil
 }
 
 func FeatureContext(s *godog.ScenarioContext) {

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -5192,6 +5192,28 @@ func (f *feature) iCallArrayMigrate(actionvalue string, parameter string) error 
 	return nil
 }
 
+func (f* feature) validateSnapshotSizeBytesMatchesVolumeCapacityGB() error {
+	if f.err != nil {
+        return f.err
+    }
+    if f.createSnapshotResponse == nil || f.createSnapshotResponse.Snapshot == nil {
+        return errors.New("Expected a valid createSnapshotResponse")
+    }
+    
+	_, _, vol, _ := f.service.GetVolumeByID(context.Background(), f.volumeID, f.service.adminClient)
+    expectedSizeBytes := int64(vol.CapacityGB)
+
+	log.Println("expected size: ", expectedSizeBytes)
+	log.Println("Snapshot size: ", f.createSnapshotResponse.Snapshot.SizeBytes)
+
+	
+    if f.createSnapshotResponse.Snapshot.SizeBytes != expectedSizeBytes {
+        return errors.New("SizeBytes in response should match the volume's CapacityGB")
+    }
+    
+    return nil
+}
+
 func FeatureContext(s *godog.ScenarioContext) {
 	f := &feature{}
 	s.Step(`^a PowerMax service$`, f.aPowerMaxService)
@@ -5451,4 +5473,5 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^I call IsIOInProgress$`, f.iCallIsIOInProgress)
 	s.Step(`^I call QueryArrayStatus with "([^"]*)" and "([^"]*)"$`, f.iCallQueryArrayStatus)
 	s.Step(`^I call ArrayMigrate with "([^"]*)", parameter "([^"]*)"$`, f.iCallArrayMigrate)
+	s.Step(`^I validate the snapshot SizeBytes matches the volume CapacityGB$`, f.validateSnapshotSizeBytesMatchesVolumeCapacityGB)
 }


### PR DESCRIPTION
# Description
This PR updates the SizeBytes field in the csi.Snapshot structure to use the volume capacity in gigabytes (vol.CapacityGB) instead of the previous calculation based on cylinder size. This change ensures that the snapshot size is accurately represented in bytes.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1792|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Ran Cert-csi 
- [x] Replication Suite
![image](https://github.com/user-attachments/assets/44021e22-6114-4284-b3fd-6a31498afca0)

- [x] SnapShot suite
![image](https://github.com/user-attachments/assets/81d58cb8-06f5-425a-bc0a-410e86164f9f)

- [x] CapcityTracking Suite
![image](https://github.com/user-attachments/assets/f4f7c0cc-aff9-42a5-bafb-2569cded316c)

