### PR TITLE
Set snapID to the snapshotName returned in snapInfo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	github.com/spf13/afero v1.12.0 // indirect
 	github.com/spf13/cast v1.7.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.etcd.io/etcd/api/v3 v3.5.17 // indirect

--- a/service/snap.go
+++ b/service/snap.go
@@ -485,6 +485,8 @@ func (s *service) LinkVolumeToVolume(ctx context.Context, symID string, vol *typ
 		}
 		return err
 	}
+	// If Auth is enabled, snap name will come back with a prefix like tn1-snapID
+	snapID = snapInfo.SnapshotName
 	// Link the Target to the created snapshot
 	err = s.LinkVolumeToSnapshot(ctx, symID, vol.VolumeID, tgtDevID, snapID, reqID, isCopy, pmaxClient)
 	if err != nil {

--- a/service/snap.go
+++ b/service/snap.go
@@ -447,8 +447,8 @@ func (s *service) GetSnapSessions(ctx context.Context, symID, deviceID string, p
 // volume as a target to a snapshot
 func (s *service) LinkVolumeToSnapshot(ctx context.Context, symID, srcDevID, tgtDevID, snapID string, reqID string, isCopy bool, pmaxClient pmax.Pmax) (err error) {
 	lockHandle := fmt.Sprintf("%s%s", srcDevID, symID)
-	lockNum := RequestLock(lockHandle, reqID)
-	defer ReleaseLock(lockHandle, reqID, lockNum)
+	lockNum := requestLockFunc(lockHandle, reqID)
+	defer releaseLockFunc(lockHandle, reqID, lockNum)
 
 	// Verify that the snapshot exists on the array
 	_, err = pmaxClient.GetSnapshotInfo(ctx, symID, srcDevID, snapID)
@@ -508,11 +508,10 @@ func (s *service) LinkVolumeToVolume(ctx context.Context, symID string, vol *typ
 
 // CreateSnapshotFromVolume creates a snapshot on a source volume
 func (s *service) CreateSnapshotFromVolume(ctx context.Context, symID string, vol *types.Volume, snapID string, TTL int64, reqID string, pmaxClient pmax.Pmax) (snapshot *types.VolumeSnapshot, err error) {
-	lockHandle := fmt.Sprintf("%s%s", vol.VolumeID, symID)
-	lockNum := RequestLock(lockHandle, reqID)
-	defer ReleaseLock(lockHandle, reqID, lockNum)
-
 	log.Debugf("Creating snapshot %s on %s", snapID, vol.VolumeID)
+	lockHandle := fmt.Sprintf("%s%s", vol.VolumeID, symID)
+	lockNum := requestLockFunc(lockHandle, reqID)
+	defer releaseLockFunc(lockHandle, reqID, lockNum)
 	deviceID := vol.VolumeID
 	// Unlink this device if it is a target of another snapshot
 	if vol.SnapSource || vol.SnapTarget {

--- a/service/snap_test.go
+++ b/service/snap_test.go
@@ -389,7 +389,7 @@ func TestLinkVolumeToVolumeWithAuth(t *testing.T) {
 
 	var TTL int64 = 1
 
-	var generation int64 = 0
+	var generation int64
 
 	// Set up the mock Pmax client with request/release lock functions and snap cleaner
 	requestLockFunc = func(_, _ string) int {

--- a/service/snap_test.go
+++ b/service/snap_test.go
@@ -15,10 +15,15 @@
 package service
 
 import (
+	"context"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/dell/csi-powermax/v2/pkg/symmetrix/mocks"
+	types "github.com/dell/gopowermax/v2/types/v100"
+	gmock "go.uber.org/mock/gomock"
 )
 
 func Test_snapCleanupQueue_Swap(t *testing.T) {
@@ -343,5 +348,79 @@ func Test_service_startSnapCleanupWorker(t *testing.T) {
 				t.Errorf("service.startSnapCleanupWorker() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// This test simulates a successful linkVolumeToVolume call when Auth is enabled
+func TestLinkVolumeToVolumeWithAuth(t *testing.T) {
+	// Create a service
+	s := &service{}
+
+	// Create a mock Pmax client
+	mockPmaxClient := mocks.NewMockPmaxClient(gmock.NewController(t))
+	sysID := "sym-123"
+
+	// Creating fields for the expected method calls
+	vol := &types.Volume{
+		VolumeID: "123",
+	}
+
+	volumeList := []types.VolumeList{
+		{
+			Name: vol.VolumeID,
+		},
+	}
+	tgtDevID := "tgt-dev-123"
+
+	tgtVolumeList := []types.VolumeList{
+		{
+			Name: tgtDevID,
+		},
+	}
+
+	snapID := "snap-123"
+
+	// snapID with the tenent prefix from Auth
+	authSnapID := "tn1-snap-123"
+
+	reqID := "req-123"
+
+	isCopy := true
+
+	var TTL int64 = 1
+
+	var generation int64 = 0
+
+	// Set up the mock Pmax client with request/release lock functions and snap cleaner
+	requestLockFunc = func(_, _ string) int {
+		return 0
+	}
+
+	releaseLockFunc = func(_, _ string, _ int) {}
+
+	s.snapCleaner = &snapCleanupWorker{
+		PollingInterval: time.Second * 1,
+		Queue:           snapCleanupQueue{},
+	}
+
+	// Set up the mock Pmax client with expected method calls
+	mockPmaxClient.EXPECT().CreateSnapshot(context.Background(), sysID, snapID, volumeList, TTL).Return(nil)
+
+	mockPmaxClient.EXPECT().GetSnapshotInfo(context.Background(), sysID, vol.VolumeID, snapID).Return(&types.VolumeSnapshot{
+		SnapshotName: authSnapID,
+	}, nil)
+
+	// Returning snapID with the tenent prefix from Auth simulates what happens when Auth is enabled and LinkVolumeToVolume is called
+	mockPmaxClient.EXPECT().GetSnapshotInfo(context.Background(), sysID, vol.VolumeID, authSnapID).Return(&types.VolumeSnapshot{
+		SnapshotName: authSnapID,
+	}, nil)
+
+	mockPmaxClient.EXPECT().ModifySnapshotS(context.Background(), sysID, volumeList, tgtVolumeList, authSnapID, Link, "", generation, isCopy).Return(nil)
+
+	// Call the LinkVolumeToVolume function
+	err := s.LinkVolumeToVolume(context.Background(), sysID, vol, tgtDevID, snapID, reqID, isCopy, mockPmaxClient)
+	// Assert that the error is nil
+	if err != nil {
+		t.Errorf("Expected nil error, but got: %v", err)
 	}
 }


### PR DESCRIPTION
# Description
SnapID is a string name, calculated via:
```
snapID := fmt.Sprintf("%s%s-%d", TempSnap, s.getClusterPrefix(), time.Now().Nanosecond())
```
When creating a volume from a volume, we pass this string to CreateSnapshotFromVolume, and then pass the same name to LinkVolumeToSnapshot. 

We assume the name returned from a snapshot created by CreateSnapshotFromVolume will still equal snapID, but this is not the case when the driver is deployed with Authorization because when auth is deployed, the snapshot gets the tenant volumePrefix added to the beginning of its name. 

This causes an issue in LinkVolumeToSnapshot, because we call it with the outdated snapID name: 
```
err = s.LinkVolumeToSnapshot(ctx, symID, vol.VolumeID, tgtDevID, snapID, reqID, isCopy, pmaxClient)
```
this results in an error because it cannot find the snapshot:
```
time="2025-03-19T15:21:27Z" level=info msg="/csi.v1.Controller/CreateVolume: REP 0747: rpc error: code = Internal desc = Failed to create volume from volume (A problem occurred modifying the snapshot resources: No snapshot information found)"
```
This error is apparent when creating a volume clone with the authorization module enabled. 

This PR is to fix the above issue by update the snapID to the name in the snapshot created by CreateSnapshotFromVolume. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1802 |

# Checklist:

- [x] Have you run format, vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- ran clone volume suite with Auth, results posted internally 
- ran clone volume suite without Auth to ensure no regresion, results posted internally 