### PR TITLE
Get SymID from configmap if secret doesnt exist

### DIFF
--- a/service/node.go
+++ b/service/node.go
@@ -1576,7 +1576,13 @@ func (s *service) nodeStartup(ctx context.Context) error {
 		log.Debug("vmHost created successfully")
 	}
 
-	symmetrixIDs = s.filterArraysByZoneInfo(s.opts.StorageArrays)
+	// Get the symmetrix ID list from Secret
+	if s.opts.StorageArrays != nil {
+		symmetrixIDs = s.filterArraysByZoneInfo(s.opts.StorageArrays)
+	} else {
+		// Get the symmetrix ID list from Configmap
+		symmetrixIDs = s.retryableGetSymmetrixIDList().SymmetrixIDs
+	}
 	log.Debug(fmt.Sprintf("GetSymmetrixIDList returned: %v", symmetrixIDs))
 
 	err = s.nodeHostSetup(ctx, portWWNs, IQNs, hostNQN, symmetrixIDs)

--- a/service/node.go
+++ b/service/node.go
@@ -1577,7 +1577,7 @@ func (s *service) nodeStartup(ctx context.Context) error {
 	}
 
 	// Get the symmetrix ID list from Secret
-	if s.opts.StorageArrays != nil {
+	if len(s.opts.StorageArrays) != nil {
 		symmetrixIDs = s.filterArraysByZoneInfo(s.opts.StorageArrays)
 	} else {
 		// Get the symmetrix ID list from Configmap

--- a/service/node.go
+++ b/service/node.go
@@ -1577,7 +1577,7 @@ func (s *service) nodeStartup(ctx context.Context) error {
 	}
 
 	// Get the symmetrix ID list from Secret
-	if len(s.opts.StorageArrays) != nil {
+	if len(s.opts.StorageArrays) > 0 {
 		symmetrixIDs = s.filterArraysByZoneInfo(s.opts.StorageArrays)
 	} else {
 		// Get the symmetrix ID list from Configmap


### PR DESCRIPTION
# Description
Get the SymIDs from reverse-proxy configmap instead when secret doesnt contain managed arrays.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1707 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Ran UT to make sure the SymIds are populated. Verified fix with new image and testing if HostIDs are creating and it was.
This is with Nightly image : Nodehostsetup starts and stops as it couldnt find SymIds
![image](https://github.com/user-attachments/assets/454ddcfe-7851-4ebc-b3a2-e3a00e132c30)
This is a test image with this fix : 
![image](https://github.com/user-attachments/assets/30ddea1c-c401-4c9d-8b0b-f124432480b8)
![image](https://github.com/user-attachments/assets/9fd74c81-18b9-4bc5-99ef-c441848e8ba4)


