### PR TITLE
Added support for n-1 patch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,16 +14,44 @@ on:  # yamllint disable-line rule:truthy
           - major
           - minor
           - patch
+          - n-1/n-2 patch (Provide input in the below box)
+      version:
+        description: "Patch version to release. example: 2.1.x (Use this only if n-1/n-2 patch is selected)"
+        required: false
+        type: string
       reverseproxyCheckInput:
         description: 'Release CSI-ReverseProxy Image'
         type: boolean
         default: false
         required: false
 jobs:
+  process-inputs:
+    name: Process Inputs
+    runs-on: ubuntu-latest
+    outputs:
+      processedVersion: ${{ steps.set-version.outputs.versionEnv }}
+    steps:
+      - name: Process input
+        id: set-version
+        shell: bash
+        run: |
+          if [[ "${{ github.event.inputs.version }}" != "" && "${{ github.event.inputs.option }}" == "n-1/n-2 patch (Provide input in the below box)" ]]; then
+            # if both version and option are provided, then version takes precedence i.e. patch release for n-1/n-2
+            echo "versionEnv=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [[ "${{ github.event.inputs.option }}" != "n-1/n-2 patch (Provide input in the below box)" ]]; then
+            # if only option is provided, then option takes precedence i.e. minor, major or patch release
+            echo "versionEnv=${{ github.event.inputs.option }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          # if neither option nor version is provided, then minor release is taken by default (Auto-release)
+          echo "versionEnv=minor" >> $GITHUB_OUTPUT
   csm-release:
+    needs: [process-inputs]
     uses: dell/common-github-actions/.github/workflows/csm-release-driver-module.yaml@main
     name: Release CSM Drivers and Modules
     with:
-      version: ${{ github.event.inputs.option }}
+      version: ${{ needs.process-inputs.outputs.processedVersion }}
       images: ${{ github.event.inputs.reverseproxyCheckInput == 'true' && 'csi-powermax,csipowermax-reverseproxy' || 'csi-powermax' }}
     secrets: inherit


### PR DESCRIPTION
# Description
Added support for n-1 patch
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1490 |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
 Tested for driver with the fork (n-1): https://github.com/harishp8889/test-powerstore-automation/actions/runs/14374596886/job/40304030998

 Tested for driver with fork (normal release): https://github.com/harishp8889/test-powerstore-automation/actions/runs/14374648455/job/40304179725