### PR TITLE
Fix: Ensure Gosec Runs on Reverseproxy

### DIFF
--- a/csireverseproxy/pkg/common/constants.go
+++ b/csireverseproxy/pkg/common/constants.go
@@ -26,7 +26,7 @@ const (
 	TestConfigDir               = "test-config"
 	TempConfigDir               = "test-config/tmp"
 	TestConfigFileName          = "config.yaml"
-	TestSecretFileName          = "secret-config.yaml"
+	TestSecretFileName          = "secret-config.yaml" // #nosec G101
 	EnvCertDirName              = "X_CSI_REVPROXY_CERT_DIR"
 	EnvTLSCertDirName           = "X_CSI_REVPROXY_TLS_CERT_DIR"
 	EnvWatchNameSpace           = "X_CSI_REVPROXY_WATCH_NAMESPACE"
@@ -34,15 +34,15 @@ const (
 	EnvConfigDirName            = "X_CSI_REVPROXY_CONFIG_DIR"
 	EnvInClusterConfig          = "X_CSI_REVPROXY_IN_CLUSTER"
 	EnvIsLeaderElectionEnabled  = "X_CSI_REVPROXY_IS_LEADER_ENABLED"
-	EnvSecretFilePath           = "X_CSI_REVPROXY_SECRET_FILEPATH"
-	EnvReverseProxyUseSecret    = "X_CSI_REVPROXY_USE_SECRET"
+	EnvSecretFilePath           = "X_CSI_REVPROXY_SECRET_FILEPATH" // #nosec G101
+	EnvReverseProxyUseSecret    = "X_CSI_REVPROXY_USE_SECRET"      // #nosec G101
 	EnvPowermaxConfigPath       = "X_CSI_POWERMAX_CONFIG_PATH"
 	DefaultNameSpace            = "powermax"
 	MaxActiveReadRequests       = 5
 	MaxOutStandingWriteRequests = 50
 	MaxActiveWriteRequests      = 4
 	MaxOutStandingReadRequests  = 50
-	DefaultSecretPath           = "/etc/powermax/config"
+	DefaultSecretPath           = "/etc/powermax/config" // #nosec G101
 	// EnvSidecarProxyPort is the port on which the reverse proxy
 	// server run, if run as a sidecar container
 	EnvSidecarProxyPort = "X_CSI_POWERMAX_SIDECAR_PROXY_PORT"

--- a/csireverseproxy/pkg/utils/utils.go
+++ b/csireverseproxy/pkg/utils/utils.go
@@ -104,12 +104,12 @@ func WriteHTTPResponse(w http.ResponseWriter, val interface{}) {
 	if err != nil {
 		fmt.Println("error:", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(err.Error()))
+		_, _ = w.Write([]byte(err.Error()))
 		return
 	}
 	_, err = w.Write(jsonBytes)
 	if err != nil {
-		w.Write([]byte(err.Error()))
+		_, _ = w.Write([]byte(err.Error()))
 		log.Error("Couldn't write to ResponseWriter")
 		w.WriteHeader(http.StatusInternalServerError)
 	}


### PR DESCRIPTION
# Description
Ensure that with the latest `gosec` changes in the common GitHub actions that `reverseproxy` is covered.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1490 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensure that `gosec` is run on the `reverseproxy` through common GitHub actions.
