### PR TITLE
Restrict zoned nodes from accessing unzoned arrays

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -1088,13 +1088,13 @@ func (s *service) filterArraysByZoneInfo(storageArrays map[string]StorageArrayCo
 		}
 	}
 
+	if len(zonedArrays) == 1 {
+		return zonedArrays
+	}
+
 	if len(zonedArrays) > 1 {
 		log.Error("More than one zoned arrays found, only one zoned array per node is supported")
 		return []string{}
-	}
-
-	if len(zonedArrays) == 1 {
-		return zonedArrays
 	}
 
 	return unzonedArrays

--- a/service/service.go
+++ b/service/service.go
@@ -1070,8 +1070,8 @@ func (s *service) filterArraysByZoneInfo(storageArrays map[string]StorageArrayCo
 	}
 
 	for arrayID, arrayConfig := range storageArrays {
-		arrayLabels := arrayConfig.Labels
 		keepArray := true
+		arrayLabels := arrayConfig.Labels
 		if len(arrayLabels) != 0 {
 			for arrayLabelKey, arrayLabelVal := range arrayLabels {
 				if nodeLabelVal, ok := nodeLabels[arrayLabelKey]; !ok || nodeLabelVal != arrayLabelVal.(string) {
@@ -1090,7 +1090,7 @@ func (s *service) filterArraysByZoneInfo(storageArrays map[string]StorageArrayCo
 
 	if len(zonedArrays) > 1 {
 		log.Error("More than one zoned arrays found, only one zoned array per node is supported")
-		return nil
+		return []string{}
 	}
 
 	if len(zonedArrays) == 1 {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -285,6 +285,55 @@ func TestFilterArraysByZoneInfo(t *testing.T) {
 			},
 			expectedArrays: []string{"array1", "array2", "array3"},
 		},
+		{
+			name: "Multiple labels all matching",
+			initFunc: func() *k8smock.MockUtilsInterface {
+				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
+				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{
+					"topology.kubernetes.io/zone": "Z1",
+					"topology.kubernetes.io/region": "R1",
+					}, nil)
+				return mockUtilsInterface
+			},
+			storageArrays: map[string]StorageArrayConfig{
+				"array1": {
+				},
+				"array2": {
+					Labels: map[string]interface{}{
+						"topology.kubernetes.io/zone": "Z1",
+						"topology.kubernetes.io/region": "R1",
+					},
+
+				},
+				"array3": {
+				},
+			},
+			expectedArrays: []string{"array2"},
+		},
+		{
+			name: "Multiple labels some matching",
+			initFunc: func() *k8smock.MockUtilsInterface {
+				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
+				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{
+					"topology.kubernetes.io/zone": "Z1",
+					"topology.kubernetes.io/region": "R2",
+					}, nil)
+				return mockUtilsInterface
+			},
+			storageArrays: map[string]StorageArrayConfig{
+				"array1": {
+				},
+				"array2": {
+					Labels: map[string]interface{}{
+						"topology.kubernetes.io/zone": "Z1",
+						"topology.kubernetes.io/region": "R1",
+					},
+				},
+				"array3": {
+				},
+			},
+			expectedArrays: []string{"array1", "array3"},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -240,8 +240,7 @@ func TestFilterArraysByZoneInfo(t *testing.T) {
 				"array1": {
 					Labels: map[string]interface{}{"topology.kubernetes.io/zone": "Z1"},
 				},
-				"array2": {
-				},
+				"array2": {},
 				"array3": {
 					Labels: map[string]interface{}{"topology.kubernetes.io/zone": "Z2"},
 				},
@@ -256,8 +255,7 @@ func TestFilterArraysByZoneInfo(t *testing.T) {
 				return mockUtilsInterface
 			},
 			storageArrays: map[string]StorageArrayConfig{
-				"array1": {
-				},
+				"array1": {},
 				"array2": {
 					Labels: map[string]interface{}{"topology.kubernetes.io/zone": "Z1"},
 				},
@@ -276,12 +274,9 @@ func TestFilterArraysByZoneInfo(t *testing.T) {
 				return mockUtilsInterface
 			},
 			storageArrays: map[string]StorageArrayConfig{
-				"array1": {
-				},
-				"array2": {
-				},
-				"array3": {
-				},
+				"array1": {},
+				"array2": {},
+				"array3": {},
 			},
 			expectedArrays: []string{"array1", "array2", "array3"},
 		},
@@ -290,23 +285,20 @@ func TestFilterArraysByZoneInfo(t *testing.T) {
 			initFunc: func() *k8smock.MockUtilsInterface {
 				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
 				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{
-					"topology.kubernetes.io/zone": "Z1",
+					"topology.kubernetes.io/zone":   "Z1",
 					"topology.kubernetes.io/region": "R1",
-					}, nil)
+				}, nil)
 				return mockUtilsInterface
 			},
 			storageArrays: map[string]StorageArrayConfig{
-				"array1": {
-				},
+				"array1": {},
 				"array2": {
 					Labels: map[string]interface{}{
-						"topology.kubernetes.io/zone": "Z1",
+						"topology.kubernetes.io/zone":   "Z1",
 						"topology.kubernetes.io/region": "R1",
 					},
-
 				},
-				"array3": {
-				},
+				"array3": {},
 			},
 			expectedArrays: []string{"array2"},
 		},
@@ -315,22 +307,20 @@ func TestFilterArraysByZoneInfo(t *testing.T) {
 			initFunc: func() *k8smock.MockUtilsInterface {
 				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
 				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{
-					"topology.kubernetes.io/zone": "Z1",
+					"topology.kubernetes.io/zone":   "Z1",
 					"topology.kubernetes.io/region": "R2",
-					}, nil)
+				}, nil)
 				return mockUtilsInterface
 			},
 			storageArrays: map[string]StorageArrayConfig{
-				"array1": {
-				},
+				"array1": {},
 				"array2": {
 					Labels: map[string]interface{}{
-						"topology.kubernetes.io/zone": "Z1",
+						"topology.kubernetes.io/zone":   "Z1",
 						"topology.kubernetes.io/region": "R1",
 					},
 				},
-				"array3": {
-				},
+				"array3": {},
 			},
 			expectedArrays: []string{"array1", "array3"},
 		},

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -26,13 +26,9 @@ import (
 
 	"github.com/cucumber/godog"
 	"github.com/dell/csi-powermax/v2/k8smock"
-	"github.com/dell/csi-powermax/v2/pkg/symmetrix"
-	"github.com/dell/csi-powermax/v2/pkg/symmetrix/mocks"
-	pmax "github.com/dell/gopowermax/v2"
 	gomock "github.com/golang/mock/gomock"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	gmock "go.uber.org/mock/gomock"
 )
 
 var (
@@ -170,22 +166,12 @@ func TestGetStorageArrays(t *testing.T) {
 func TestFilterArraysByZoneInfo(t *testing.T) {
 	testCases := []struct {
 		name           string
-		pmaxClient     pmax.Pmax
-		secretParams   *viper.Viper
-		getClient      func() *mocks.MockPmaxClient
-		opts           Opts
 		expectedArrays []string
 		storageArrays  map[string]StorageArrayConfig
 		initFunc       func() *k8smock.MockUtilsInterface
 	}{
 		{
 			name: "Storage array and node labels match",
-			getClient: func() *mocks.MockPmaxClient {
-				c := mocks.NewMockPmaxClient(gmock.NewController(t))
-				c.EXPECT().WithSymmetrixID("array1").AnyTimes().Return(c)
-				symmetrix.Initialize([]string{"array1"}, c)
-				return c
-			},
 			initFunc: func() *k8smock.MockUtilsInterface {
 				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
 				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{"topology.kubernetes.io/zone": "Z1"}, nil)
@@ -200,12 +186,6 @@ func TestFilterArraysByZoneInfo(t *testing.T) {
 		},
 		{
 			name: "Storage array and node labels do not match",
-			getClient: func() *mocks.MockPmaxClient {
-				c := mocks.NewMockPmaxClient(gmock.NewController(t))
-				c.EXPECT().WithSymmetrixID("array1").AnyTimes().Return(c)
-				symmetrix.Initialize([]string{"array1"}, c)
-				return c
-			},
 			initFunc: func() *k8smock.MockUtilsInterface {
 				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
 				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{"topology.kubernetes.io/region": "R1"}, nil)
@@ -220,12 +200,6 @@ func TestFilterArraysByZoneInfo(t *testing.T) {
 		},
 		{
 			name: "Storage array and node do not have zone info",
-			getClient: func() *mocks.MockPmaxClient {
-				c := mocks.NewMockPmaxClient(gmock.NewController(t))
-				c.EXPECT().WithSymmetrixID("array1").AnyTimes().Return(c)
-				symmetrix.Initialize([]string{"array1"}, c)
-				return c
-			},
 			initFunc: func() *k8smock.MockUtilsInterface {
 				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
 				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{}, nil)
@@ -238,11 +212,83 @@ func TestFilterArraysByZoneInfo(t *testing.T) {
 			},
 			expectedArrays: []string{"array1"},
 		},
+		{
+			name: "Multiple storage arrays in same zone",
+			initFunc: func() *k8smock.MockUtilsInterface {
+				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
+				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{"topology.kubernetes.io/zone": "Z1"}, nil)
+				return mockUtilsInterface
+			},
+			storageArrays: map[string]StorageArrayConfig{
+				"array1": {
+					Labels: map[string]interface{}{"topology.kubernetes.io/zone": "Z1"},
+				},
+				"array2": {
+					Labels: map[string]interface{}{"topology.kubernetes.io/zone": "Z1"},
+				},
+			},
+			expectedArrays: []string{},
+		},
+		{
+			name: "Mix of zoned and unzoned arrays/node in zone/case 1",
+			initFunc: func() *k8smock.MockUtilsInterface {
+				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
+				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{"topology.kubernetes.io/zone": "Z1"}, nil)
+				return mockUtilsInterface
+			},
+			storageArrays: map[string]StorageArrayConfig{
+				"array1": {
+					Labels: map[string]interface{}{"topology.kubernetes.io/zone": "Z1"},
+				},
+				"array2": {
+				},
+				"array3": {
+					Labels: map[string]interface{}{"topology.kubernetes.io/zone": "Z2"},
+				},
+			},
+			expectedArrays: []string{"array1"},
+		},
+		{
+			name: "Mix of zoned and unzoned arrays/node in zone/case 2",
+			initFunc: func() *k8smock.MockUtilsInterface {
+				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
+				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{"topology.kubernetes.io/zone": "Z1"}, nil)
+				return mockUtilsInterface
+			},
+			storageArrays: map[string]StorageArrayConfig{
+				"array1": {
+				},
+				"array2": {
+					Labels: map[string]interface{}{"topology.kubernetes.io/zone": "Z1"},
+				},
+				"array3": {
+					Labels: map[string]interface{}{"topology.kubernetes.io/zone": "Z2"},
+				},
+			},
+			expectedArrays: []string{"array2"},
+		},
+		{
+			name: "Multiple unzoned arrays",
+			initFunc: func() *k8smock.MockUtilsInterface {
+				mockUtilsInterface := k8smock.NewMockUtilsInterface(gomock.NewController(t))
+				// The label does not matter as the arrays are unzoned.
+				mockUtilsInterface.EXPECT().GetNodeLabels("node1").Return(map[string]string{"topology.kubernetes.io/zone": "Z1"}, nil)
+				return mockUtilsInterface
+			},
+			storageArrays: map[string]StorageArrayConfig{
+				"array1": {
+				},
+				"array2": {
+				},
+				"array3": {
+				},
+			},
+			expectedArrays: []string{"array1", "array2", "array3"},
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create a new service instance for testing
 			s := &service{
 				opts: Opts{
 					NodeName:     "node1",
@@ -250,10 +296,8 @@ func TestFilterArraysByZoneInfo(t *testing.T) {
 				},
 				k8sUtils: tc.initFunc(),
 			}
-			tc.pmaxClient = tc.getClient()
-			// Call the function and check the results
 			filteredArrays := s.filterArraysByZoneInfo(tc.storageArrays)
-			log.Infof("Filtered arrays: %v", filteredArrays)
+			log.Debugf("Filtered arrays: %v", filteredArrays)
 			if !reflect.DeepEqual(filteredArrays, tc.expectedArrays) {
 				t.Errorf("Expected %v, got %v", tc.expectedArrays, filteredArrays)
 			}


### PR DESCRIPTION
# Description
Updated requirements clarification. A node that is zoned to an array must not access arrays that are not zoned. Also add check for case where two arrays could be zoned.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1748|

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- [x] Tested pod creation in mixed zoned and unzoned environment using minimal SC.
- [x] Tested pod creation in unzoned (regression) case with legacy SC.
