### PR TITLE
minor fix for multi-az and hostMB hostIO

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -617,8 +617,8 @@ func (s *service) CreateVolume(
 	if err != nil || sg == nil {
 		log.Debug(fmt.Sprintf("Unable to find storage group: %s", storageGroupName))
 		hostLimitsParam := &types.SetHostIOLimitsParam{
-			HostIOLimitMBSec:    hostIOsec,
-			HostIOLimitIOSec:    hostMBsec,
+			HostIOLimitMBSec:    hostMBsec,
+			HostIOLimitIOSec:    hostIOsec,
 			DynamicDistribution: hostDynDistribution,
 		}
 		optionalPayload := make(map[string]interface{})
@@ -4452,7 +4452,7 @@ func (s *service) resolveParameter(params map[string]string, arrayID, param, def
 		if array, ok := s.opts.StorageArrays[arrayID]; ok {
 			for k, value := range array.Parameters {
 				if strings.EqualFold(param, k) {
-					return value.(string)
+					return fmt.Sprintf("%v", value)
 				}
 			}
 		}


### PR DESCRIPTION
# Description
In CreateVolume fix minor bug with hostMB and hostIO.
In resolveParameter instead of casting value to string, return a string regardless of value (avoid panic on parameters coming in as int).

A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
