### PR TITLE
Fix for Test_service_getArrayIDFromTopologyRequirement

### DIFF
--- a/csireverseproxy/Makefile
+++ b/csireverseproxy/Makefile
@@ -19,6 +19,7 @@ format:
 	@gofmt -w -s .
 
 clean:
+	rm -f cover.out coverage.txt
 	go clean
 
 build:

--- a/service/controller_test.go
+++ b/service/controller_test.go
@@ -2606,7 +2606,7 @@ func Test_service_getArrayIDFromTopologyRequirement(t *testing.T) {
 					},
 				},
 			},
-			want: "000000000002",
+			want: "000000000002,000000000003", // non deterministic due to map iteration
 		},
 		{
 			name: "multiple segments in topology requirements, single candidate",
@@ -2769,7 +2769,7 @@ func Test_service_getArrayIDFromTopologyRequirement(t *testing.T) {
 			}
 
 			got := s.getArrayIDFromTopologyRequirement(tt.topologyRequirement)
-			assert.Equal(t, tt.want, got)
+			assert.Contains(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
# Description
Fix UT. Since the key ordering in a dictionary is not deterministic we sometimes see failures in a case where one of many possible keys could be returned. 

Also updated the unit-test target to match what the GitHub actions run in order to get more developers to run unit tests.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [ ] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
