### PR TITLE
Support nvme-cli 2.11 (OCP 4.19, RHEL9.6, RCOS 9.6)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,11 +14,11 @@ require (
 	github.com/dell/dell-csi-extensions/migration v1.8.0
 	github.com/dell/dell-csi-extensions/podmon v1.8.0
 	github.com/dell/dell-csi-extensions/replication v1.11.0
-	github.com/dell/gobrick v1.14.0
+	github.com/dell/gobrick v1.14.1-0.20250624004701-1c68c8c05f2f
 	github.com/dell/gocsi v1.14.0
 	github.com/dell/gofsutil v1.19.0
 	github.com/dell/goiscsi v1.12.0
-	github.com/dell/gonvme v1.11.0
+	github.com/dell/gonvme v1.11.1-0.20250623220042-71afc9447376
 	github.com/dell/gopowermax/v2 v2.10.1-0.20250618232101-be8479ebaf9b
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/golang/mock v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/dell/dell-csi-extensions/replication v1.11.0 h1:Fn/4Xa6Up7Duz5P8MxiMJ
 github.com/dell/dell-csi-extensions/replication v1.11.0/go.mod h1:4ckSKNS4P2PnPXtscOFeHdbjemjnh4tdbNWtJTbbwsQ=
 github.com/dell/gobrick v1.14.0 h1:uB/Hb7k8kva9p1vX8LoplCUEdifdw/ixLJkmK0b2NFs=
 github.com/dell/gobrick v1.14.0/go.mod h1:kZdqQaOJpAz7PK8rgVYrmDN0qYrkR/8KiljaPl3N3Tg=
+github.com/dell/gobrick v1.14.1-0.20250624004701-1c68c8c05f2f h1:u2zZw6k1GhapS1ex8PyfZtIBTRldF3kHTxxLVM5xxSU=
+github.com/dell/gobrick v1.14.1-0.20250624004701-1c68c8c05f2f/go.mod h1:ML2lu6+tPdLeE+4eF/+Fytl/C8Ekce2qT/AKijjXqFs=
 github.com/dell/gocsi v1.14.0 h1:DinuonGUvr4P898+xX0zk/ZHAvetJrr48GhKyHS3PL0=
 github.com/dell/gocsi v1.14.0/go.mod h1:YhF+LnH5S8t96qotoLk6wUjMzCwSy8rmnqvx7h4Nc3s=
 github.com/dell/gofsutil v1.19.0 h1:41Hx24Tlie37UbOwatHgNAV0nq+KQysrhABXCnpOs+E=
@@ -120,6 +122,8 @@ github.com/dell/goiscsi v1.12.0 h1:hxY9SaJLS/WQiDKQ9Vplguvg6jcF8wqTFGk5VzgFVj8=
 github.com/dell/goiscsi v1.12.0/go.mod h1:nMLnEG6QBpouHxFRMxpmJA6X+Nrr3KeN9mr5n2gV+5M=
 github.com/dell/gonvme v1.11.0 h1:nt5jL4mNDNtvWftM2U2WqGtFiBIgKHvloLOMN9NYOqc=
 github.com/dell/gonvme v1.11.0/go.mod h1:3bgVCRevHuVWR4UOV2uv5UksaJP5SiCzrgQZHqihaYA=
+github.com/dell/gonvme v1.11.1-0.20250623220042-71afc9447376 h1:W8KGEWIUGNvHs0sP9ewd9M0/Tv/rvfjp2BzkzUNzpBA=
+github.com/dell/gonvme v1.11.1-0.20250623220042-71afc9447376/go.mod h1:lzVtOeQBoq0Jedw66MMawBTjVmQSNsKExMC0HhuZ47c=
 github.com/dell/gopowermax/v2 v2.10.0 h1:eu8VmBU5P3PN2HHi7+/zptNrDdRG971/NWEYl8B7Dx8=
 github.com/dell/gopowermax/v2 v2.10.0/go.mod h1:5CDcZJLGZV6ghCNjuOjp9tmiZ8Y5nDIUNNzE8iho1tg=
 github.com/dell/gopowermax/v2 v2.10.1-0.20250618232101-be8479ebaf9b h1:D2k/szfAOpeXs1r/jDsipTwDez5YqygqsoobxzalE2Y=

--- a/service/node.go
+++ b/service/node.go
@@ -168,7 +168,7 @@ func (s *service) NodeStageVolume(
 	// Save volume WWN to node disk
 	err = s.writeWWNFile(id, volumeWWN)
 	if err != nil {
-		log.Error("Could not write WWN file: " + volumeWWN)
+		log.Errorf("Could not write WWN file: %s: %v", volumeWWN, err)
 	}
 
 	// Attach RDM
@@ -415,6 +415,8 @@ func (s *service) connectNVMeTCPDevice(ctx context.Context, data publishContextD
 	for _, t := range data.nvmetcpTargets {
 		targets = append(targets, gobrick.NVMeTargetInfo{Target: t.Target, Portal: t.Portal})
 	}
+
+	log.Debugf("connectNVMeTCPDevice: connecting volume with targets %v", targets)
 	// separate context to prevent 15 seconds cancel from kubernetes
 	connectorCtx, cFunc := context.WithTimeout(context.Background(), time.Second*120)
 	connectorCtx = setLogFields(connectorCtx, logFields)
@@ -3139,7 +3141,7 @@ func (s *service) writeWWNFile(id, volumeWWN string) error {
 	wwnFileName := fmt.Sprintf("%s/%s.wwn", s.privDir, id)
 	err := ioutil.WriteFile(wwnFileName, []byte(volumeWWN), 0o644) // #nosec G306
 	if err != nil {
-		return status.Errorf(codes.Internal, "Could not read WWN file: %s", wwnFileName)
+		return status.Errorf(codes.Internal, "Could not write WWN file %s: %v", wwnFileName, err)
 	}
 	return nil
 }
@@ -3150,7 +3152,7 @@ func (s *service) readWWNFile(id string) (string, error) {
 	wwnFileName := fmt.Sprintf("%s/%s.wwn", s.privDir, id)
 	wwnBytes, err := ioutil.ReadFile(wwnFileName) // #nosec G304
 	if err != nil {
-		return "", status.Errorf(codes.Internal, "Could not read WWN file: %s", wwnFileName)
+		return "", status.Errorf(codes.Internal, "Could not read WWN file %s: %v", wwnFileName, err)
 	}
 	volumeWWN := string(wwnBytes)
 	return volumeWWN, nil


### PR DESCRIPTION
# Description
Support nvme-cli 2.11 which uses a different format in the nvme list -o json results. This release is used in OCP 4.19 and RHEL/RCOS 9.6 releases.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1896|

# Checklist:

- [X] Have you run format,vet & lint checks against your submission?
- [ ] Have you made sure that the code compiles?
- [ ] Did you run the unit & integration tests successfully?
- [ ] Have you maintained at least 90% code coverage?
- [ ] Have you commented your code, particularly in hard-to-understand areas
- [ ] Have you done corresponding changes to the documentation
- [X] Did you run tests in a real Kubernetes cluster?
- [X] Backward compatibility is not broken

# How Has This Been Tested?
- [] 
- [] 
