### PR TITLE
Ensure NVMe Volumes Reattach Correctly After Pod Deletion

### DIFF
--- a/service/node.go
+++ b/service/node.go
@@ -627,11 +627,11 @@ func (s *service) disconnectVolume(reqID, symID, devID, volumeWWN string) error 
 		case IscsiTransportProtocol:
 			_ = s.iscsiConnector.DisconnectVolumeByDeviceName(nodeUnstageCtx, deviceName)
 		case NvmeTCPTransportProtocol:
-			_ = s.nvmeTCPConnector.DisconnectVolumeByDeviceName(nodeUnstageCtx, deviceName)
-			devPath, err := os.Readlink(symlinkPath)
-			log.WithFields(f).Infof("NVMEDEBUG devPath %s, error %v", devPath, err)
-			_, err = os.ReadDir(sysBlock + deviceName)
-			log.WithFields(f).Infof("NVMEDEBUG os.ReadDir %s, error %v", sysBlock + deviceName, err)
+			err := s.nvmeTCPConnector.DisconnectVolumeByDeviceName(nodeUnstageCtx, deviceName)
+			if err != nil {
+				log.WithFields(f).Errorf("failed to disconnect volume by device name %s with error %s", deviceName, err.Error())
+				continue
+			}
 			cancel()
 			return nil
 		}

--- a/service/node.go
+++ b/service/node.go
@@ -628,11 +628,11 @@ func (s *service) disconnectVolume(reqID, symID, devID, volumeWWN string) error 
 			_ = s.iscsiConnector.DisconnectVolumeByDeviceName(nodeUnstageCtx, deviceName)
 		case NvmeTCPTransportProtocol:
 			err := s.nvmeTCPConnector.DisconnectVolumeByDeviceName(nodeUnstageCtx, deviceName)
+			cancel()
 			if err != nil {
 				log.WithFields(f).Errorf("failed to disconnect volume by device name %s with error %s", deviceName, err.Error())
 				continue
 			}
-			cancel()
 			return nil
 		}
 		cancel()

--- a/service/node.go
+++ b/service/node.go
@@ -627,10 +627,14 @@ func (s *service) disconnectVolume(reqID, symID, devID, volumeWWN string) error 
 		case IscsiTransportProtocol:
 			_ = s.iscsiConnector.DisconnectVolumeByDeviceName(nodeUnstageCtx, deviceName)
 		case NvmeTCPTransportProtocol:
-			_ = s.nvmeTCPConnector.DisconnectVolumeByDeviceName(nodeUnstageCtx, deviceName)
+			err := s.nvmeTCPConnector.DisconnectVolumeByDeviceName(nodeUnstageCtx, deviceName)
+			log.WithFields(f).Infof("NVMEDEBUG DisconnectVolumeByDeviceName error %s", err.Error())
 		}
 		cancel()
 		time.Sleep(disconnectVolumeRetryTime)
+
+		devPath, err := os.Readlink(symlinkPath)
+		log.WithFields(f).Infof("NVMEDEBUG devPath %s, error %s", devPath, err.Error())
 
 		if s.arrayTransportProtocolMap[symID] != NvmeTCPTransportProtocol {
 			// Check that the /sys/block/DeviceName actually exists

--- a/service/node.go
+++ b/service/node.go
@@ -632,10 +632,12 @@ func (s *service) disconnectVolume(reqID, symID, devID, volumeWWN string) error 
 		cancel()
 		time.Sleep(disconnectVolumeRetryTime)
 
-		// Check that the /sys/block/DeviceName actually exists
-		if _, err := ioutil.ReadDir(sysBlock + deviceName); err != nil {
-			// If not, make sure the symlink is removed
-			os.Remove(symlinkPath) // #nosec G20
+		if s.arrayTransportProtocolMap[symID] != NvmeTCPTransportProtocol {
+			// Check that the /sys/block/DeviceName actually exists
+			if _, err := os.ReadDir(sysBlock + deviceName); err != nil {
+				// If not, make sure the symlink is removed
+				os.Remove(symlinkPath) // #nosec G20
+			}
 		}
 	}
 

--- a/service/node.go
+++ b/service/node.go
@@ -628,13 +628,13 @@ func (s *service) disconnectVolume(reqID, symID, devID, volumeWWN string) error 
 			_ = s.iscsiConnector.DisconnectVolumeByDeviceName(nodeUnstageCtx, deviceName)
 		case NvmeTCPTransportProtocol:
 			err := s.nvmeTCPConnector.DisconnectVolumeByDeviceName(nodeUnstageCtx, deviceName)
-			log.WithFields(f).Infof("NVMEDEBUG DisconnectVolumeByDeviceName error %s", err.Error())
+			log.WithFields(f).Infof("NVMEDEBUG DisconnectVolumeByDeviceName error %v", err)
 		}
 		cancel()
 		time.Sleep(disconnectVolumeRetryTime)
 
 		devPath, err := os.Readlink(symlinkPath)
-		log.WithFields(f).Infof("NVMEDEBUG devPath %s, error %s", devPath, err.Error())
+		log.WithFields(f).Infof("NVMEDEBUG devPath %s, error %v", devPath, err)
 
 		if s.arrayTransportProtocolMap[symID] != NvmeTCPTransportProtocol {
 			// Check that the /sys/block/DeviceName actually exists


### PR DESCRIPTION
# Description
This PR addresses an issue where NVMe volumes were not being re-attached to node after the pods consuming them were deleted. The root cause was the CSI driver removing the device symlink under `/dev/disk/by-id` during the NodeUnstageVolume operation.
With this fix, the driver ensures that the device symlink for NVMe volumes is preserved during NodeUnstageVolume, allowing proper reattachment when a new pod is scheduled.


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1957 |

# Checklist:

- [x] Have you run format,vet & lint checks against your submission?
- [x] Have you made sure that the code compiles?
- [x] Did you run the unit & integration tests successfully?
- [x] Have you maintained at least 90% code coverage?
- [x] Have you commented your code, particularly in hard-to-understand areas
- [x] Have you done corresponding changes to the documentation
- [x] Did you run tests in a real Kubernetes cluster?
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- [x] Ran OCP e2e with NVMe/TCP configuration