### PR TITLE
Add log to node isVolumeMounted error

### DIFF
--- a/service/node.go
+++ b/service/node.go
@@ -1468,6 +1468,7 @@ func (s *service) NodeGetVolumeStats(
 		isMounted, err := isVolumeMounted(ctx, volName, volPath)
 		log.Debug("---- isMounted ----", isMounted)
 		if err != nil {
+			log.Error(err.Error())
 			abnormal = true
 			msg = fmt.Sprintf("Error getting mount info for volume %s", id)
 		}


### PR DESCRIPTION
When the isVolumeMounted fails the log does not get showned.
This hides any errors from GetMountInfoFromDevice